### PR TITLE
rearrange order of ACK in I2Cread

### DIFF
--- a/Firmware/I2C.c
+++ b/Firmware/I2C.c
@@ -84,10 +84,6 @@ extern int cmderror;
 unsigned int I2Cread(void) {
     unsigned char c = 0;
     if (ackPending) {
-        bpSP;
-        //bpWmessage(MSG_ACK);
-        BPMSG1060;
-        bpSP;
         if (i2cmode == SOFT) {
             bbI2Cack();
         }
@@ -96,6 +92,10 @@ unsigned int I2Cread(void) {
             hwi2csendack(0); //all other reads get an ACK
         }
 #endif
+	bpSP;
+        //bpWmessage(MSG_ACK);
+        BPMSG1060;
+        bpSP;
         ackPending = 0;
     }
 


### PR DESCRIPTION
For I2C reads, rearrange the printing of messages to _after_ the ACK is generated. This adds about 0.4 ms of space between the ACK of one byte and the first bit of the next. Many devices need to clock stretch between here, but can't with v3 hardware. This fixes issues with bulk reads on many I2C devices, provided they don't need to stretch the clock longer than 0.4 ms.

(to be clear, this doesn't add extra time between bytes, it removes 0.4 ms that was happening before the ACK, and moves it to after)