### PR TITLE
bug fix for "Jump to bootloader" and use of BUSPIRATEV4 define where needed

### DIFF
--- a/Firmware/baseIO.c
+++ b/Firmware/baseIO.c
@@ -281,8 +281,8 @@ void InitializeUART1(void) { // if termspeed==9 it is custom
     U1STAbits.UTXEN = 1;
     IFS0bits.U1RXIF = 0;
 }
-unsigned char UART1TXRdy(void) {
-      return  U1STAbits.UTXBF; 
+unsigned char UART1TXEmpty(void) {
+      return U1STAbits.TRMT; 
 }
 
 unsigned char UART1RXRdy(void) {
@@ -444,7 +444,7 @@ void WAITTXEmpty(void) {
     WaitInReady();
 }
 
-unsigned char UART1TXRdy(void) {
+unsigned char UART1TXEmpty(void) {
     return 1;
 }
 
@@ -508,8 +508,8 @@ void InitializeUART1(void) { // if termspeed==9 it is custom
     U1STAbits.UTXEN = 1;
     IFS0bits.U1RXIF = 0;
 }
-unsigned char UART1TXRdy(void) {
-      return  U1STAbits.UTXBF; 
+unsigned char UART1TXEmpty(void) {
+      return  U1STAbits.TRMT; 
 }
 
 unsigned char UART1RXRdy(void) {

--- a/Firmware/baseIO.h
+++ b/Firmware/baseIO.h
@@ -98,7 +98,7 @@ void UART1TXInt(void);
 
 //is byte available in RX buffer?
 unsigned char UART1RXRdy(void); 
-unsigned char UART1TXRdy(void);
+unsigned char UART1TXEmpty(void);
 //get a byte from UART
 unsigned char UART1RX(void);
 void WAITTXEmpty(void);
@@ -113,7 +113,6 @@ unsigned char CheckCommsError(void);
 void UART1Speed(unsigned char brg);
 //Initialize the terminal UART for the speed currently set in bpConfig.termSpeed
 void InitializeUART1(void);
-unsigned char UART1TXRdy(void);
 //
 //
 // Ring buffer for UART

--- a/Firmware/basic.c
+++ b/Firmware/basic.c
@@ -559,7 +559,7 @@ int evaluate(void)
 */
 
 void interpreter(void)
-{	int len;
+{	int len=0;
 	unsigned int lineno;
 	int i;
 //	int pc; 			//became global

--- a/Firmware/jtag.c
+++ b/Firmware/jtag.c
@@ -250,7 +250,7 @@ void jtagSetup(void){
 
 //this is a new write routine, untested. See old below...
 unsigned char jtagWriteByte(unsigned char c){
-        unsigned char i,j,a,l;
+        unsigned char i,j,a=0,l;
 
         jtagClockLow();//begin with clock low...
 
@@ -293,7 +293,7 @@ unsigned char jtagWriteByte(unsigned char c){
 }
 
 unsigned char jtagReadByte(void){
-        unsigned char i,j,a;
+        unsigned char i,j,a=0;
 
         jtagClockLow();//begin with clock low...
 

--- a/Firmware/onboardEEPROM.c
+++ b/Firmware/onboardEEPROM.c
@@ -17,6 +17,8 @@
 #include "base.h"
 #include "onboardEEPROM.h"
 
+#if defined (BUSPIRATEV4)
+
 unsigned char eetest(void){
 	unsigned char c,l;
 	eei2cSetup();
@@ -139,3 +141,5 @@ unsigned int eeWriteByte(char wByte, unsigned long wAddr)
 
 	return RetVal;
 }
+
+#endif

--- a/Firmware/procMenu.c
+++ b/Firmware/procMenu.c
@@ -658,7 +658,7 @@ bpv4reset:
                     //bpWstring("\r\nHiZ>"); //was printed twice
 #else
                     BPMSG1093;
-                    while (0 == UART1TXRdy()); //wait untill TX finishes
+                    while (0 == UART1TXEmpty()); //wait untill TX finishes
                     asm("RESET");
                     //}
 #endif
@@ -668,7 +668,7 @@ bpv4reset:
                         BPMSG1094;
                         bpDelayMS(100);
                         bpInit(); // turn off nasty things, cleanup first needed?
-                        while (0 == UART1TXRdy()); //wait untill TX finishes
+                        while (0 == UART1TXEmpty()); //wait untill TX finishes
                         asm volatile ("mov #BLJUMPADDRESS, w1 \n" //bootloader location
                                     "goto w1 \n");
                     }
@@ -1861,7 +1861,7 @@ void setBaudRate(void) {
     //bpWmessage(MSG_OPT_TERMBAUD_ADJUST); //show 'adjust and press space dialog'
     BPMSG1134;
     BPMSG1251;
-    while (0 == UART1TXRdy()); //wait for TX to finish or reinit flushes part of prompt string from buffer
+    while (0 == UART1TXEmpty()); //wait for TX to finish or reinit flushes part of prompt string from buffer
 
     if (bpConfig.termSpeed == 9) {
         UART1Speed(brg);

--- a/Firmware/smps.c
+++ b/Firmware/smps.c
@@ -18,6 +18,8 @@
 #include "base.h"
 #include "procMenu.h"
 
+#if defined (BUSPIRATEV4)
+
 unsigned int PWM_dutycycle, V_out, reading;
 	
 void smpsStart(unsigned int V) {	
@@ -69,3 +71,5 @@ void __attribute__((interrupt, no_auto_psv)) _ADC1Interrupt() {
 		OC5R = PWM_dutycycle;					// otherwise continue normally
 	}
 }
+
+#endif


### PR DESCRIPTION
There appears to be a long-standing bug that causes an endless loop when attempting the "Jump to bootloader" menu option:

http://dangerousprototypes.com/forum/viewtopic.php?f=4&t=5052&p=54931

Both onboardEEPROM.c and smps.c contain functions only called in the V4 variant and utilize resources not created for V3 (causing compilation errors).  Enclosing these functions with an ifdef (as is done with other code in Bus Pirate) allows these files to compile in V3 without needing a different project file.
