### PR TITLE
Mark constant tables as "const".

### DIFF
--- a/Firmware/1wire.c
+++ b/Firmware/1wire.c
@@ -517,7 +517,7 @@ unsigned char OWVerify()
 }
 
 // TEST BUILD
-static unsigned char dscrc_table[] = {
+static const unsigned char dscrc_table[] = {
         0, 94,188,226, 97, 63,221,131,194,156,126, 32,163,253, 31, 65,
       157,195, 33,127,252,162, 64, 30, 95,  1,227,189, 62, 96,130,220,
        35,125,159,193, 66, 28,254,160,225,191, 93,  3,128,222, 60, 98,

--- a/Firmware/I2C.c
+++ b/Firmware/I2C.c
@@ -59,7 +59,7 @@ unsigned char hwi2cread(void);
 void binI2CversionString(void);
 
 #ifdef BP_USE_I2C_HW
-static unsigned char I2Cspeed[] = {157, 37, 13}; //100,400,1000khz; datasheet pg 145
+static const unsigned char I2Cspeed[] = {157, 37, 13}; //100,400,1000khz; datasheet pg 145
 #endif
 
 //software functions

--- a/Firmware/SPI.c
+++ b/Firmware/SPI.c
@@ -66,7 +66,7 @@ struct _SPI {
     unsigned char csl : 1; // to /CS or  not to CS
 } spiSettings;
 
-static unsigned char SPIspeed[] = {0b00000, 0b11000, 0b11100, 0b11101}; //30,125,250,1000khz; datasheet pg 142
+static const unsigned char SPIspeed[] = {0b00000, 0b11000, 0b11100, 0b11101}; //30,125,250,1000khz; datasheet pg 142
 
 /*
 // move into a .h or other .c??? 
@@ -605,7 +605,7 @@ rawSPI mode:
  * 00000010 - Bulk Memory Read from Flash
 	
  */
-static unsigned char binSPIspeed[]={0b00000,0b11000,0b11100,0b11101,0b00011,0b01011,0b10011,0b11011}; //00=30,01=125,10=250,11=1000khz, 100=2mhz,101=2.667mhz,  110=4mhz, 111=8mhz; datasheet pg 142
+static const unsigned char binSPIspeed[]={0b00000,0b11000,0b11100,0b11101,0b00011,0b01011,0b10011,0b11011}; //00=30,01=125,10=250,11=1000khz, 100=2mhz,101=2.667mhz,  110=4mhz, 111=8mhz; datasheet pg 142
 
 void binSPIversionString(void) {
     bpWstring("SPI1");

--- a/Firmware/UART.c
+++ b/Firmware/UART.c
@@ -53,7 +53,7 @@ struct _UART{
 
 void UARTsetup_exc(void);
 
-static unsigned int UART2speed[]={13332,3332,1666,832,416,207,103,68,34,127};//BRG:300,1200,2400,4800,9600,19200,38400,57600,115200, 31250,
+static const unsigned int UART2speed[]={13332,3332,1666,832,416,207,103,68,34,127};//BRG:300,1200,2400,4800,9600,19200,38400,57600,115200, 31250,
 
 unsigned int UARTread(void)
 {	unsigned int c;
@@ -678,7 +678,7 @@ peripheral settings
 # 100wxxyz � config, w=output type, xx=databits and parity, y=stop bits, z=rx polarity (default :00000)
 # 101wxxyz � read config
 */
-static unsigned int binUARTspeed[]={13332,3332,1666,832,416,207,127,103,68,34,};//BRG:300,1200,2400,4800,9600,19200,31250,38400,57600,115200
+static const unsigned int binUARTspeed[]={13332,3332,1666,832,416,207,127,103,68,34,};//BRG:300,1200,2400,4800,9600,19200,31250,38400,57600,115200
 
 void binUARTversionString(void){bpWstring("ART1");}
 

--- a/Firmware/baseIO.c
+++ b/Firmware/baseIO.c
@@ -177,7 +177,7 @@ void bpWdec(unsigned char c) {
 }
 
 //output an 8bit/byte hex value to the user terminal
-const unsigned char HEXASCII[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+static const unsigned char HEXASCII[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
 void bpWhex(unsigned int c) {
     unsigned int b;


### PR DESCRIPTION
Resource usage compared to 65bc53297ea98fe6f36ac6a301e0d2c19d12d88f:

RAM: 11912 -> 11600 (-312)
ROM: 59224 -> 59306 (+82)