### PR TITLE
Fix ../hd44780.c:21:17: fatal error: SPI.h: No such file or directory

### DIFF
--- a/BPv4-bootloader/firmware-v1/picusb.h
+++ b/BPv4-bootloader/firmware-v1/picusb.h
@@ -315,7 +315,7 @@ typedef struct BDENTRY {
 #if defined(PIC_24F)
 
 #define MyProcessor
-#include <p24fxxxx.h>
+#include <p24Fxxxx.h>
 
 #define USTAT_ODD_EVEN (4)              // JTR PIC24 fixup potentially ?? Only required when ping-pong buffering is enabled. 
 #define USTAT_ODD_EVEN_SHIFT (2)        // JTR these are required for BD* calculations and are different for the PIC24

--- a/Firmware/hd44780.c
+++ b/Firmware/hd44780.c
@@ -18,7 +18,7 @@
 
 #ifdef BP_ENABLE_HD44780_SUPPORT
 
-#include "SPI.h"
+#include "spi.h"
 #include "base.h"
 #include "procMenu.h"
 


### PR DESCRIPTION
I don't know how nobody met this problem before, maybe the older MPLABs were not case sensitive regarding the header file names. After this change it compiles... My build environment: Ubuntu Linux 16.04.1 x64, MPLAB X v3.40 and MPLAB XC v1.26 compiler with PRO mode enabled (60 days free evaluation license, so that I could enable "3" level optimization for speed)