### PR TITLE
No inline for WaitOutReady() to fix "symbol .loopOut is already defined"

### DIFF
--- a/Firmware/dp_usb/cdc.c
+++ b/Firmware/dp_usb/cdc.c
@@ -256,7 +256,7 @@ void __attribute__((noinline)) WaitOutReady() {
 #endif /* __XC16_VERSION__ == 1026 */
 }
 
-void WaitInReady() {
+void __attribute__((noinline)) WaitInReady() {
 #if __XC16_VERSION__ == 1026
     
     /* 

--- a/Firmware/dp_usb/cdc.c
+++ b/Firmware/dp_usb/cdc.c
@@ -231,7 +231,7 @@ void cdc_set_control_line_state_status(void) {
     usb_unset_in_handler(0);
 }
 
-void WaitOutReady() {    
+void __attribute__((noinline)) WaitOutReady() {
 #if __XC16_VERSION__ == 1026
     
     /* 


### PR DESCRIPTION
See more information here - https://github.com/BusPirate/Bus_Pirate/issues/11