### PR TITLE
Set CRT_STARTMODE in linker scripts

### DIFF
--- a/Bootloaders/BPv3-bootloader/firmware-v4.5/p24FJ64GA002.gld
+++ b/Bootloaders/BPv3-bootloader/firmware-v4.5/p24FJ64GA002.gld
@@ -37,6 +37,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 OPTIONAL(-lfx)

--- a/Bootloaders/BPv3-bootloader/upgrader-v2tov4/APP 24FJ64GA002.gld
+++ b/Bootloaders/BPv3-bootloader/upgrader-v2tov4/APP 24FJ64GA002.gld
@@ -4,6 +4,18 @@
 */
 
 OUTPUT_ARCH("24FJ64GA002")
+
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
+
 EXTERN(__resetPRI)
 EXTERN(__resetALT)
 

--- a/Bootloaders/BPv3-bootloader/upgrader-v4tov4/p24FJ64GA002.gld
+++ b/Bootloaders/BPv3-bootloader/upgrader-v4tov4/p24FJ64GA002.gld
@@ -5,6 +5,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 

--- a/Firmware-Alternates/Blink_MODE_LED/p24FJ64GA002.gld
+++ b/Firmware-Alternates/Blink_MODE_LED/p24FJ64GA002.gld
@@ -5,6 +5,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 

--- a/Firmware-Alternates/firmware-STK500v2/p24FJ64GA002.gld
+++ b/Firmware-Alternates/firmware-STK500v2/p24FJ64GA002.gld
@@ -5,6 +5,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 

--- a/Firmware-Alternates/firmware-XSVFplayer/p24FJ64GA002.gld
+++ b/Firmware-Alternates/firmware-XSVFplayer/p24FJ64GA002.gld
@@ -5,6 +5,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 

--- a/Firmware/p24FJ256GB106.gld
+++ b/Firmware/p24FJ256GB106.gld
@@ -37,6 +37,16 @@
 OUTPUT_ARCH("24FJ256GB106")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 OPTIONAL(-lfx)

--- a/Firmware/p24FJ64GA002.gld
+++ b/Firmware/p24FJ64GA002.gld
@@ -37,6 +37,16 @@
 OUTPUT_ARCH("24FJ64GA002")
 CRT0_STARTUP(crt0_standard.o)
 CRT1_STARTUP(crt1_standard.o)
+#if __XC16_VERSION__ > 1027
+/*
+ * Define how to startup, by default we initialize
+ * everything as normal; change to crt_start_mode to
+ * preserve preserved data on a restart
+ *
+ * Or define your own __crt_start_mode fucntion
+ */
+CRT_STARTMODE(crt_start_mode_normal)
+#endif
 
 OPTIONAL(-lpPIC24Fxxx)
 OPTIONAL(-lfx)


### PR DESCRIPTION
XC16 1.30 and newer will produce a linker warning if CRT_STARTMODE
is not set. The script fragment is copied directly from the compiler
distribution.