### PR TITLE
Fix USB communications when optimizations are enabled

### DIFF
--- a/Bootloaders/BPv4-bootloader/firmware-v1/usb_stack.h
+++ b/Bootloaders/BPv4-bootloader/firmware-v1/usb_stack.h
@@ -160,7 +160,8 @@ typedef struct BDENTRY {
 #else
 typedef struct BDENTRY {
         unsigned char BDCNT;    // JTR PIC24 fixup Note that BDCNT & BDSTAT are swapped from the PIC18!!
-        unsigned char BDSTAT;   // Smacks head. Go on, yo know you want to. 
+                                // Smacks head. Go on, yo know you want to.
+        volatile unsigned char BDSTAT;
         unsigned char *BDADDR;
 } BDentry;
 #endif

--- a/Firmware/dp_usb/cdc.c
+++ b/Firmware/dp_usb/cdc.c
@@ -231,54 +231,12 @@ void cdc_set_control_line_state_status(void) {
     usb_unset_in_handler(0);
 }
 
-void __attribute__((noinline)) WaitOutReady() {
-#if __XC16_VERSION__ >= 1026
-    
-    /* 
-     * XC16 1.26 generates invalid code for this function when applying
-     * optimisations.
-     * 
-     * See also https://github.com/BusPirate/Bus_Pirate/issues/11
-     */
-    
-    /* BDSTAT is at offset 1 */
-    asm volatile (
-        ".loopOut:               \n"
-        "\tmov.w _CDC_Outbdp, w0 \n"
-        "\tcp0.b [++w0]          \n"
-        "\tbra N, .loopOut       \n"
-    );
-    
-#else
-    
+void WaitOutReady(void) {
     while (CDC_Outbdp->BDSTAT & UOWN) {};
-    
-#endif /* __XC16_VERSION__ >= 1026 */
 }
 
-void __attribute__((noinline)) WaitInReady() {
-#if __XC16_VERSION__ >= 1026
-    
-    /* 
-     * XC16 1.26 generates invalid code for this function when applying
-     * optimisations.
-     * 
-     * See also https://github.com/BusPirate/Bus_Pirate/issues/11
-     */
-    
-    /* BDSTAT is at offset 1 */
-    asm volatile (
-        ".loopIn:               \n"
-        "\tmov.w _CDC_Inbdp, w0 \n"
-        "\tcp0.b [++w0]         \n"
-        "\tbra N, .loopIn       \n"
-    );
-    
-#else
-    
+void WaitInReady(void) {
     while (CDC_Inbdp->BDSTAT & UOWN) {};
-    
-#endif /* __XC16_VERSION__ >= 1026 */
 }
 
 /******************************************************************************/

--- a/Firmware/dp_usb/picusb.h
+++ b/Firmware/dp_usb/picusb.h
@@ -521,7 +521,7 @@ typedef unsigned int usb_uep_t; // JTR PIC24 fixup potentially ?? changed from c
 typedef struct BDENTRY {
     unsigned char BDCNT; // JTR PIC24 fixup Note that the endianness is swapped from the PIC18
                          // This is probably what had people hitting their heads!
-    unsigned char BDSTAT;
+    volatile unsigned char BDSTAT;
     unsigned char *BDADDR;
 } BDentry;
 


### PR DESCRIPTION
The USB buffer descriptor BDSTAT field was not marked as volatile,
which turned polling functions like WaitOutReady() into infinite loops
when optimizations were enabled.

Self-test passes even when built with -O3.