### PR TITLE
Use linker garbage collection to remove unused strings

### DIFF
--- a/Firmware/busPirate.X/nbproject/configurations.xml
+++ b/Firmware/busPirate.X/nbproject/configurations.xml
@@ -372,7 +372,7 @@
         <property key="oXC16ld-nostdlib" value="false"/>
         <property key="oXC16ld-stackguard" value="16"/>
         <property key="preprocessor-macros" value=""/>
-        <property key="remove-unused-sections" value="false"/>
+        <property key="remove-unused-sections" value="true"/>
         <property key="report-memory-usage" value="true"/>
         <property key="secure-eeprom" value="no_eeprom"/>
         <property key="secure-flash" value="no_flash"/>
@@ -934,7 +934,7 @@
         <property key="oXC16ld-nostdlib" value="false"/>
         <property key="oXC16ld-stackguard" value="16"/>
         <property key="preprocessor-macros" value=""/>
-        <property key="remove-unused-sections" value="false"/>
+        <property key="remove-unused-sections" value="true"/>
         <property key="report-memory-usage" value="true"/>
         <property key="secure-eeprom" value="no_eeprom"/>
         <property key="secure-flash" value="no_flash"/>

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -18,35 +18,25 @@
 
 #include "base.h"
 
-/**
- * The packed strings buffer.
- * 
- * Declared as a function rather than an array since it is being stored in the
- * code segment of the firmware, otherwise the compiler complains.
- * 
- * @todo Fiddle with the linker scripts to see if this can be set as an extern
- *       uint8_t pointer.
- */
-extern void bp_messages(void);
-
-void bp_message_write_buffer(size_t offset, size_t length) {
+void bp_message_write_buffer(void (*strptr)(void), size_t length) {
     size_t index;
+    size_t str = (size_t)strptr;
 
-    for (index = offset; index < (offset + length); index++) {
+    for (index = 0; index < length; index++) {
         switch (index % 3) {
             case 0:
-               UART1TX(__builtin_tblrdl((size_t) &bp_messages +
-                       ((index / 3) << 1)) & 0xFF); 
+               UART1TX(__builtin_tblrdl(str+((index/3)<< 1))
+                       & 0xFF);
                break;
 
             case 1:
-                UART1TX((__builtin_tblrdl((size_t) &bp_messages +
-                        ((index / 3) << 1)) >> 8) & 0xFF);
+                UART1TX((__builtin_tblrdl(str+((index/3)<< 1)) >> 8)
+                        & 0xFF);
                 break;
 
             case 2:
-                UART1TX(__builtin_tblrdh((size_t) &bp_messages +
-                        ((index / 3) << 1)) & 0xFF);
+                UART1TX(__builtin_tblrdh(str+((index/3)<< 1))
+                        & 0xFF);
                 break;
 
             default:
@@ -55,8 +45,8 @@ void bp_message_write_buffer(size_t offset, size_t length) {
     }
 }
 
-void bp_message_write_line(size_t offset, size_t length) {
-    bp_message_write_buffer(offset, length);
+void bp_message_write_line(void (*strptr)(void), size_t length) {
+    bp_message_write_buffer(strptr, length);
     bpBR;
 }
 

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -39,19 +39,19 @@ void print_help(void);
  * Prints a given byte array range from the packed string buffer to the serial
  * port.
  * 
- * @param[in] offset the starting offset in the packed string buffer.
+ * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_buffer(size_t offset, size_t length);
+void bp_message_write_buffer(void (*strptr)(void), size_t length);
 
 /**
  * Prints a given byte array range from the packed string buffer to the serial
  * port, appending a CRLF pair at the end.
  * 
- * @param[in] offset the starting offset in the packed string buffer.
+ * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_line(size_t offset, size_t length);
+void bp_message_write_line(void (*strptr)(void), size_t length);
 
 /**
  * Prompts the user to agree or not on a particular question.

--- a/Firmware/messages_v3.h
+++ b/Firmware/messages_v3.h
@@ -1,286 +1,567 @@
 #ifndef BP_MESSAGES_V3_H
 #define BP_MESSAGES_V3_H
 
-#define BPMSG1001 bp_message_write_line(0, 36)
-#define BPMSG1004 bp_message_write_line(36, 41)
-#define BPMSG1005 bp_message_write_buffer(77, 14)
-#define BPMSG1006 bp_message_write_line(91, 13)
-#define BPMSG1007 bp_message_write_line(104, 23)
-#define BPMSG1008 bp_message_write_buffer(127, 6)
-#define BPMSG1009 bp_message_write_line(133, 211)
-#define BPMSG1010 bp_message_write_line(344, 19)
-#define BPMSG1011 bp_message_write_line(363, 13)
-#define BPMSG1012 bp_message_write_line(376, 43)
-#define BPMSG1013 bp_message_write_buffer(419, 17)
-#define BPMSG1014 bp_message_write_line(436, 16)
-#define BPMSG1015 bp_message_write_line(452, 15)
-#define BPMSG1017 bp_message_write_buffer(467, 10)
-#define BPMSG1019 bp_message_write_buffer(477, 9)
-#define BPMSG1020 bp_message_write_buffer(486, 21)
-#define BPMSG1021 bp_message_write_buffer(507, 20)
-#define BPMSG1022 bp_message_write_buffer(527, 27)
-#define BPMSG1023 bp_message_write_buffer(554, 26)
-#define BPMSG1024 bp_message_write_buffer(580, 21)
-#define BPMSG1025 bp_message_write_buffer(601, 24)
-#define BPMSG1026 bp_message_write_buffer(625, 16)
-#define BPMSG1027 bp_message_write_buffer(641, 14)
-#define BPMSG1028 bp_message_write_line(655, 12)
-#define BPMSG1029 bp_message_write_line(667, 17)
-#define BPMSG1030 bp_message_write_buffer(684, 17)
-#define BPMSG1033 bp_message_write_buffer(701, 16)
-#define BPMSG1034 bp_message_write_line(717, 10)
-#define BPMSG1037 bp_message_write_line(727, 31)
-#define BPMSG1038 bp_message_write_buffer(758, 15)
-#define BPMSG1039 bp_message_write_buffer(773, 14)
-#define BPMSG1040 bp_message_write_line(787, 8)
-#define BPMSG1041 bp_message_write_line(795, 7)
-#define BPMSG1042 bp_message_write_line(802, 14)
-#define BPMSG1044 bp_message_write_buffer(816, 15)
-#define BPMSG1045 bp_message_write_buffer(831, 1)
-#define BPMSG1047 bp_message_write_buffer(832, 6)
-#define BPMSG1048 bp_message_write_buffer(838, 8)
-#define BPMSG1049 bp_message_write_buffer(846, 11)
-#define BPMSG1050 bp_message_write_line(857, 7)
-#define BPMSG1051 bp_message_write_line(864, 9)
-#define BPMSG1052 bp_message_write_line(873, 12)
-#define BPMSG1059 bp_message_write_line(885, 33)
-#define BPMSG1064 bp_message_write_line(918, 37)
-#define BPMSG1066 bp_message_write_buffer(955, 53)
-#define BPMSG1067 bp_message_write_buffer(1008, 44)
-#define BPMSG1068 bp_message_write_buffer(1052, 16)
-#define BPMSG1069 bp_message_write_buffer(1068, 53)
-#define BPMSG1070 bp_message_write_line(1121, 46)
-#define BPMSG1071 bp_message_write_line(1167, 7)
-#define BPMSG1072 bp_message_write_line(1174, 34)
-#define BPMSG1073 bp_message_write_line(1208, 6)
-#define BPMSG1074 bp_message_write_buffer(1214, 14)
-#define BPMSG1075 bp_message_write_buffer(1228, 3)
-#define BPMSG1076 bp_message_write_line(1231, 3)
-#define BPMSG1077 bp_message_write_line(1234, 7)
-#define BPMSG1078 bp_message_write_line(1241, 12)
-#define BPMSG1079 bp_message_write_line(1253, 13)
-#define BPMSG1080 bp_message_write_buffer(1266, 8)
-#define BPMSG1081 bp_message_write_buffer(1274, 7)
-#define BPMSG1082 bp_message_write_line(1281, 21)
-#define BPMSG1083 bp_message_write_line(1302, 32)
-#define BPMSG1084 bp_message_write_buffer(1334, 7)
-#define BPMSG1085 bp_message_write_line(1341, 5)
-#define BPMSG1086 bp_message_write_line(1346, 22)
-#define BPMSG1087 bp_message_write_line(1368, 21)
-#define BPMSG1088 bp_message_write_line(1389, 29)
-#define BPMSG1089 bp_message_write_buffer(1418, 21)
-#define BPMSG1091 bp_message_write_buffer(1439, 20)
-#define BPMSG1092 bp_message_write_line(1459, 26)
-#define BPMSG1093 bp_message_write_line(1485, 5)
-#define BPMSG1094 bp_message_write_line(1490, 10)
-#define BPMSG1095 bp_message_write_buffer(1500, 22)
-#define BPMSG1096 bp_message_write_buffer(1522, 17)
-#define BPMSG1097 bp_message_write_buffer(1539, 18)
-#define BPMSG1098 bp_message_write_buffer(1557, 12)
-#define BPMSG1099 bp_message_write_buffer(1569, 6)
-#define BPMSG1100 bp_message_write_line(1575, 2)
-#define BPMSG1101 bp_message_write_buffer(1577, 7)
-#define BPMSG1102 bp_message_write_buffer(1584, 6)
-#define BPMSG1103 bp_message_write_line(1590, 8)
-#define BPMSG1104 bp_message_write_line(1598, 8)
-#define BPMSG1105 bp_message_write_line(1606, 14)
-#define BPMSG1106 bp_message_write_line(1620, 14)
-#define BPMSG1107 bp_message_write_line(1634, 16)
-#define BPMSG1108 bp_message_write_buffer(1650, 13)
-#define BPMSG1109 bp_message_write_buffer(1663, 10)
-#define BPMSG1110 bp_message_write_buffer(1673, 21)
-#define BPMSG1111 bp_message_write_line(1694, 23)
-#define BPMSG1112 bp_message_write_line(1717, 14)
-#define BPMSG1114 bp_message_write_line(1731, 21)
-#define BPMSG1115 bp_message_write_line(1752, 7)
-#define BPMSG1117 bp_message_write_buffer(1759, 6)
-#define BPMSG1118 bp_message_write_line(1765, 30)
-#define BPMSG1119 bp_message_write_line(1795, 12)
-#define BPMSG1120 bp_message_write_line(1807, 34)
-#define BPMSG1121 bp_message_write_line(1841, 30)
-#define BPMSG1123 bp_message_write_buffer(1871, 27)
-#define BPMSG1124 bp_message_write_buffer(1898, 28)
-#define BPMSG1126 bp_message_write_buffer(1926, 13)
-#define BPMSG1127 bp_message_write_line(1939, 34)
-#define BPMSG1128 bp_message_write_line(1973, 18)
-#define BPMSG1133 bp_message_write_line(1991, 141)
-#define BPMSG1134 bp_message_write_line(2132, 20)
-#define BPMSG1135 bp_message_write_buffer(2152, 14)
-#define BPMSG1136 bp_message_write_buffer(2166, 5)
-#define BPMSG1137 bp_message_write_buffer(2171, 6)
-#define BPMSG1163 bp_message_write_line(2177, 63)
-#define BPMSG1164 bp_message_write_line(2240, 4)
-#define BPMSG1165 bp_message_write_buffer(2244, 3)
-#define BPMSG1166 bp_message_write_buffer(2247, 8)
-#define BPMSG1167 bp_message_write_buffer(2255, 8)
-#define BPMSG1168 bp_message_write_buffer(2263, 8)
-#define BPMSG1169 bp_message_write_buffer(2271, 4)
-#define BPMSG1170 bp_message_write_line(2275, 14)
-#define BPMSG1171 bp_message_write_buffer(2289, 2)
-#define BPMSG1172 bp_message_write_buffer(2291, 3)
-#define BPMSG1173 bp_message_write_buffer(2294, 4)
-#define BPMSG1174 bp_message_write_buffer(2298, 3)
-#define BPMSG1175 bp_message_write_line(2301, 8)
-#define BPMSG1176 bp_message_write_line(2309, 10)
-#define BPMSG1177 bp_message_write_line(2319, 10)
-#define BPMSG1178 bp_message_write_line(2329, 32)
-#define BPMSG1179 bp_message_write_buffer(2361, 6)
-#define BPMSG1180 bp_message_write_line(2367, 8)
-#define BPMSG1181 bp_message_write_buffer(2375, 4)
-#define BPMSG1182 bp_message_write_buffer(2379, 3)
-#define BPMSG1183 bp_message_write_buffer(2382, 4)
-#define BPMSG1184 bp_message_write_buffer(2386, 2)
-#define BPMSG1185 bp_message_write_line(2388, 3)
-#define BPMSG1186 bp_message_write_line(2391, 5)
-#define BPMSG1187 bp_message_write_line(2396, 154)
-#define BPMSG1188 bp_message_write_line(2550, 53)
-#define BPMSG1189 bp_message_write_line(2603, 67)
-#define BPMSG1190 bp_message_write_line(2670, 49)
-#define BPMSG1191 bp_message_write_buffer(2719, 32)
-#define BPMSG1192 bp_message_write_line(2751, 52)
-#define BPMSG1194 bp_message_write_buffer(2803, 3)
-#define BPMSG1195 bp_message_write_buffer(2806, 3)
-#define BPMSG1196 bp_message_write_buffer(2809, 15)
-#define BPMSG1197 bp_message_write_buffer(2824, 15)
-#define BPMSG1199 bp_message_write_buffer(2839, 84)
-#define BPMSG1200 bp_message_write_buffer(2923, 33)
-#define BPMSG1201 bp_message_write_buffer(2956, 50)
-#define BPMSG1202 bp_message_write_buffer(3006, 32)
-#define BPMSG1203 bp_message_write_buffer(3038, 106)
-#define BPMSG1204 bp_message_write_line(3144, 11)
-#define BPMSG1206 bp_message_write_line(3155, 14)
-#define BPMSG1207 bp_message_write_line(3169, 28)
-#define BPMSG1208 bp_message_write_line(3197, 20)
-#define BPMSG1209 bp_message_write_line(3217, 34)
-#define BPMSG1210 bp_message_write_buffer(3251, 7)
-#define BPMSG1211 bp_message_write_line(3258, 27)
-#define BPMSG1212 bp_message_write_line(3285, 2)
-#define BPMSG1213 bp_message_write_line(3287, 20)
-#define BPMSG1214 bp_message_write_line(3307, 18)
-#define BPMSG1216 bp_message_write_line(3325, 29)
-#define BPMSG1219 bp_message_write_line(3354, 152)
-#define BPMSG1220 bp_message_write_line(3506, 36)
-#define BPMSG1221 bp_message_write_line(3542, 4)
-#define BPMSG1222 bp_message_write_line(3546, 5)
-#define BPMSG1223 bp_message_write_line(3551, 10)
-#define BPMSG1226 bp_message_write_line(3561, 10)
-#define BPMSG1227 bp_message_write_buffer(3571, 26)
-#define BPMSG1228 bp_message_write_buffer(3597, 10)
-#define BPMSG1229 bp_message_write_line(3607, 9)
-#define BPMSG1232 bp_message_write_line(3616, 11)
-#define BPMSG1233 bp_message_write_line(3627, 70)
-#define BPMSG1234 bp_message_write_buffer(3697, 4)
-#define BPMSG1237 bp_message_write_buffer(3701, 8)
-#define BPMSG1238 bp_message_write_line(3709, 38)
-#define BPMSG1239 bp_message_write_line(3747, 28)
-#define BPMSG1240 bp_message_write_line(3775, 16)
-#define BPMSG1241 bp_message_write_line(3791, 14)
-#define BPMSG1242 bp_message_write_line(3805, 15)
-#define BPMSG1243 bp_message_write_line(3820, 5)
-#define BPMSG1244 bp_message_write_line(3825, 14)
-#define BPMSG1245 bp_message_write_buffer(3839, 11)
-#define BPMSG1248 bp_message_write_line(3850, 28)
-#define BPMSG1250 bp_message_write_line(3878, 15)
-#define BPMSG1251 bp_message_write_line(3893, 17)
-#define BPMSG1252 bp_message_write_buffer(3910, 27)
-#define BPMSG1254 bp_message_write_line(3937, 19)
-#define BPMSG1255 bp_message_write_line(3956, 12)
-#define BPMSG1280 bp_message_write_line(3968, 19)
-#define BPMSG1281 bp_message_write_line(3987, 14)
-#define BPMSG1282 bp_message_write_line(4001, 47)
-#define BPMSG1283 bp_message_write_buffer(4048, 15)
-#define BPMSG1284 bp_message_write_buffer(4063, 15)
-#define BPMSG1285 bp_message_write_line(4078, 4)
-#define HLP1000 bp_message_write_line(4082, 33)
-#define HLP1001 bp_message_write_line(4115, 76)
-#define HLP1002 bp_message_write_line(4191, 38)
-#define HLP1003 bp_message_write_line(4229, 40)
-#define HLP1004 bp_message_write_line(4269, 21)
-#define HLP1005 bp_message_write_line(4290, 27)
-#define HLP1006 bp_message_write_line(4317, 40)
-#define HLP1007 bp_message_write_line(4357, 27)
-#define HLP1008 bp_message_write_line(4384, 46)
-#define HLP1009 bp_message_write_line(4430, 21)
-#define HLP1010 bp_message_write_line(4451, 35)
-#define HLP1011 bp_message_write_line(4486, 46)
-#define HLP1012 bp_message_write_line(4532, 28)
-#define HLP1013 bp_message_write_line(4560, 33)
-#define HLP1014 bp_message_write_line(4593, 28)
-#define HLP1015 bp_message_write_line(4621, 37)
-#define HLP1016 bp_message_write_line(4658, 33)
-#define HLP1017 bp_message_write_line(4691, 25)
-#define HLP1018 bp_message_write_line(4716, 31)
-#define HLP1019 bp_message_write_line(4747, 41)
-#define HLP1020 bp_message_write_line(4788, 37)
-#define HLP1021 bp_message_write_line(4825, 54)
-#define HLP1022 bp_message_write_line(4879, 62)
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(4941, 4)
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(4945, 62)
-#define MSG_ACK bp_message_write_buffer(5007, 3)
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(5010, 3)
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(5013, 5)
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(5018, 2)
-#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(5020, 22)
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(5042, 2)
-#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(5044, 2)
-#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(5046, 2)
-#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(5048, 2)
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(5050, 13)
-#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(5063, 2)
-#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(5065, 2)
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(5067, 3)
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(5070, 20)
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(5090, 17)
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(5107, 61)
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(5168, 2)
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(5170, 4)
-#define MSG_I2C_PINS_STATE bp_message_write_line(5174, 11)
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(5185, 4)
-#define MSG_I2C_START_BIT bp_message_write_line(5189, 13)
-#define MSG_I2C_STOP_BIT bp_message_write_line(5202, 12)
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(5214, 4)
-#define MSG_MODE_HEADER_END bp_message_write_line(5218, 2)
-#define MSG_NACK bp_message_write_buffer(5220, 4)
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(5224, 34)
-#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(5258, 4)
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(5262, 4)
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(5266, 12)
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(5278, 79)
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(5357, 36)
-#define MSG_PWM_HZ_MARKER bp_message_write_line(5393, 3)
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(5396, 12)
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(5408, 13)
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(5421, 25)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(5446, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(5452, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(5458, 10)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(5468, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(5474, 7)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(5481, 11)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(5492, 6)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(5498, 15)
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(5513, 45)
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(5558, 3)
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(5561, 63)
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(5624, 8)
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(5632, 6)
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(5638, 56)
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(5694, 16)
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(5710, 20)
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(5730, 23)
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(5753, 4)
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(5757, 59)
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(5816, 16)
-#define MSG_SPI_CS_DISABLED bp_message_write_line(5832, 11)
-#define MSG_SPI_CS_ENABLED bp_message_write_line(5843, 10)
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(5853, 29)
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(5882, 4)
-#define MSG_SPI_PINS_STATE bp_message_write_line(5886, 16)
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(5902, 4)
-#define MSG_UART_PINS_STATE bp_message_write_line(5906, 11)
-#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(5917, 33)
-#define MSG_UART_RESET_TO_EXIT bp_message_write_line(5950, 13)
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(5963, 36)
-#define MSG_VREG_TOO_LOW bp_message_write_line(5999, 31)
+void BPMSG1001_str(void);
+#define BPMSG1001 bp_message_write_line(BPMSG1001_str, 36)
+void BPMSG1004_str(void);
+#define BPMSG1004 bp_message_write_line(BPMSG1004_str, 41)
+void BPMSG1005_str(void);
+#define BPMSG1005 bp_message_write_buffer(BPMSG1005_str, 14)
+void BPMSG1006_str(void);
+#define BPMSG1006 bp_message_write_line(BPMSG1006_str, 13)
+void BPMSG1007_str(void);
+#define BPMSG1007 bp_message_write_line(BPMSG1007_str, 23)
+void BPMSG1008_str(void);
+#define BPMSG1008 bp_message_write_buffer(BPMSG1008_str, 6)
+void BPMSG1009_str(void);
+#define BPMSG1009 bp_message_write_line(BPMSG1009_str, 211)
+void BPMSG1010_str(void);
+#define BPMSG1010 bp_message_write_line(BPMSG1010_str, 19)
+void BPMSG1011_str(void);
+#define BPMSG1011 bp_message_write_line(BPMSG1011_str, 13)
+void BPMSG1012_str(void);
+#define BPMSG1012 bp_message_write_line(BPMSG1012_str, 43)
+void BPMSG1013_str(void);
+#define BPMSG1013 bp_message_write_buffer(BPMSG1013_str, 17)
+void BPMSG1014_str(void);
+#define BPMSG1014 bp_message_write_line(BPMSG1014_str, 16)
+void BPMSG1015_str(void);
+#define BPMSG1015 bp_message_write_line(BPMSG1015_str, 15)
+void BPMSG1017_str(void);
+#define BPMSG1017 bp_message_write_buffer(BPMSG1017_str, 10)
+void BPMSG1019_str(void);
+#define BPMSG1019 bp_message_write_buffer(BPMSG1019_str, 9)
+void BPMSG1020_str(void);
+#define BPMSG1020 bp_message_write_buffer(BPMSG1020_str, 21)
+void BPMSG1021_str(void);
+#define BPMSG1021 bp_message_write_buffer(BPMSG1021_str, 20)
+void BPMSG1022_str(void);
+#define BPMSG1022 bp_message_write_buffer(BPMSG1022_str, 27)
+void BPMSG1023_str(void);
+#define BPMSG1023 bp_message_write_buffer(BPMSG1023_str, 26)
+void BPMSG1024_str(void);
+#define BPMSG1024 bp_message_write_buffer(BPMSG1024_str, 21)
+void BPMSG1025_str(void);
+#define BPMSG1025 bp_message_write_buffer(BPMSG1025_str, 24)
+void BPMSG1026_str(void);
+#define BPMSG1026 bp_message_write_buffer(BPMSG1026_str, 16)
+void BPMSG1027_str(void);
+#define BPMSG1027 bp_message_write_buffer(BPMSG1027_str, 14)
+void BPMSG1028_str(void);
+#define BPMSG1028 bp_message_write_line(BPMSG1028_str, 12)
+void BPMSG1029_str(void);
+#define BPMSG1029 bp_message_write_line(BPMSG1029_str, 17)
+void BPMSG1030_str(void);
+#define BPMSG1030 bp_message_write_buffer(BPMSG1030_str, 17)
+void BPMSG1033_str(void);
+#define BPMSG1033 bp_message_write_buffer(BPMSG1033_str, 16)
+void BPMSG1034_str(void);
+#define BPMSG1034 bp_message_write_line(BPMSG1034_str, 10)
+void BPMSG1037_str(void);
+#define BPMSG1037 bp_message_write_line(BPMSG1037_str, 31)
+void BPMSG1038_str(void);
+#define BPMSG1038 bp_message_write_buffer(BPMSG1038_str, 15)
+void BPMSG1039_str(void);
+#define BPMSG1039 bp_message_write_buffer(BPMSG1039_str, 14)
+void BPMSG1040_str(void);
+#define BPMSG1040 bp_message_write_line(BPMSG1040_str, 8)
+void BPMSG1041_str(void);
+#define BPMSG1041 bp_message_write_line(BPMSG1041_str, 7)
+void BPMSG1042_str(void);
+#define BPMSG1042 bp_message_write_line(BPMSG1042_str, 14)
+void BPMSG1044_str(void);
+#define BPMSG1044 bp_message_write_buffer(BPMSG1044_str, 15)
+void BPMSG1045_str(void);
+#define BPMSG1045 bp_message_write_buffer(BPMSG1045_str, 1)
+void BPMSG1047_str(void);
+#define BPMSG1047 bp_message_write_buffer(BPMSG1047_str, 6)
+void BPMSG1048_str(void);
+#define BPMSG1048 bp_message_write_buffer(BPMSG1048_str, 8)
+void BPMSG1049_str(void);
+#define BPMSG1049 bp_message_write_buffer(BPMSG1049_str, 11)
+void BPMSG1050_str(void);
+#define BPMSG1050 bp_message_write_line(BPMSG1050_str, 7)
+void BPMSG1051_str(void);
+#define BPMSG1051 bp_message_write_line(BPMSG1051_str, 9)
+void BPMSG1052_str(void);
+#define BPMSG1052 bp_message_write_line(BPMSG1052_str, 12)
+void BPMSG1059_str(void);
+#define BPMSG1059 bp_message_write_line(BPMSG1059_str, 33)
+void BPMSG1064_str(void);
+#define BPMSG1064 bp_message_write_line(BPMSG1064_str, 37)
+void BPMSG1066_str(void);
+#define BPMSG1066 bp_message_write_buffer(BPMSG1066_str, 53)
+void BPMSG1067_str(void);
+#define BPMSG1067 bp_message_write_buffer(BPMSG1067_str, 44)
+void BPMSG1068_str(void);
+#define BPMSG1068 bp_message_write_buffer(BPMSG1068_str, 16)
+void BPMSG1069_str(void);
+#define BPMSG1069 bp_message_write_buffer(BPMSG1069_str, 53)
+void BPMSG1070_str(void);
+#define BPMSG1070 bp_message_write_line(BPMSG1070_str, 46)
+void BPMSG1071_str(void);
+#define BPMSG1071 bp_message_write_line(BPMSG1071_str, 7)
+void BPMSG1072_str(void);
+#define BPMSG1072 bp_message_write_line(BPMSG1072_str, 34)
+void BPMSG1073_str(void);
+#define BPMSG1073 bp_message_write_line(BPMSG1073_str, 6)
+void BPMSG1074_str(void);
+#define BPMSG1074 bp_message_write_buffer(BPMSG1074_str, 14)
+void BPMSG1075_str(void);
+#define BPMSG1075 bp_message_write_buffer(BPMSG1075_str, 3)
+void BPMSG1076_str(void);
+#define BPMSG1076 bp_message_write_line(BPMSG1076_str, 3)
+void BPMSG1077_str(void);
+#define BPMSG1077 bp_message_write_line(BPMSG1077_str, 7)
+void BPMSG1078_str(void);
+#define BPMSG1078 bp_message_write_line(BPMSG1078_str, 12)
+void BPMSG1079_str(void);
+#define BPMSG1079 bp_message_write_line(BPMSG1079_str, 13)
+void BPMSG1080_str(void);
+#define BPMSG1080 bp_message_write_buffer(BPMSG1080_str, 8)
+void BPMSG1081_str(void);
+#define BPMSG1081 bp_message_write_buffer(BPMSG1081_str, 7)
+void BPMSG1082_str(void);
+#define BPMSG1082 bp_message_write_line(BPMSG1082_str, 21)
+void BPMSG1083_str(void);
+#define BPMSG1083 bp_message_write_line(BPMSG1083_str, 32)
+void BPMSG1084_str(void);
+#define BPMSG1084 bp_message_write_buffer(BPMSG1084_str, 7)
+void BPMSG1085_str(void);
+#define BPMSG1085 bp_message_write_line(BPMSG1085_str, 5)
+void BPMSG1086_str(void);
+#define BPMSG1086 bp_message_write_line(BPMSG1086_str, 22)
+void BPMSG1087_str(void);
+#define BPMSG1087 bp_message_write_line(BPMSG1087_str, 21)
+void BPMSG1088_str(void);
+#define BPMSG1088 bp_message_write_line(BPMSG1088_str, 29)
+void BPMSG1089_str(void);
+#define BPMSG1089 bp_message_write_buffer(BPMSG1089_str, 21)
+void BPMSG1091_str(void);
+#define BPMSG1091 bp_message_write_buffer(BPMSG1091_str, 20)
+void BPMSG1092_str(void);
+#define BPMSG1092 bp_message_write_line(BPMSG1092_str, 26)
+void BPMSG1093_str(void);
+#define BPMSG1093 bp_message_write_line(BPMSG1093_str, 5)
+void BPMSG1094_str(void);
+#define BPMSG1094 bp_message_write_line(BPMSG1094_str, 10)
+void BPMSG1095_str(void);
+#define BPMSG1095 bp_message_write_buffer(BPMSG1095_str, 22)
+void BPMSG1096_str(void);
+#define BPMSG1096 bp_message_write_buffer(BPMSG1096_str, 17)
+void BPMSG1097_str(void);
+#define BPMSG1097 bp_message_write_buffer(BPMSG1097_str, 18)
+void BPMSG1098_str(void);
+#define BPMSG1098 bp_message_write_buffer(BPMSG1098_str, 12)
+void BPMSG1099_str(void);
+#define BPMSG1099 bp_message_write_buffer(BPMSG1099_str, 6)
+void BPMSG1100_str(void);
+#define BPMSG1100 bp_message_write_line(BPMSG1100_str, 2)
+void BPMSG1101_str(void);
+#define BPMSG1101 bp_message_write_buffer(BPMSG1101_str, 7)
+void BPMSG1102_str(void);
+#define BPMSG1102 bp_message_write_buffer(BPMSG1102_str, 6)
+void BPMSG1103_str(void);
+#define BPMSG1103 bp_message_write_line(BPMSG1103_str, 8)
+void BPMSG1104_str(void);
+#define BPMSG1104 bp_message_write_line(BPMSG1104_str, 8)
+void BPMSG1105_str(void);
+#define BPMSG1105 bp_message_write_line(BPMSG1105_str, 14)
+void BPMSG1106_str(void);
+#define BPMSG1106 bp_message_write_line(BPMSG1106_str, 14)
+void BPMSG1107_str(void);
+#define BPMSG1107 bp_message_write_line(BPMSG1107_str, 16)
+void BPMSG1108_str(void);
+#define BPMSG1108 bp_message_write_buffer(BPMSG1108_str, 13)
+void BPMSG1109_str(void);
+#define BPMSG1109 bp_message_write_buffer(BPMSG1109_str, 10)
+void BPMSG1110_str(void);
+#define BPMSG1110 bp_message_write_buffer(BPMSG1110_str, 21)
+void BPMSG1111_str(void);
+#define BPMSG1111 bp_message_write_line(BPMSG1111_str, 23)
+void BPMSG1112_str(void);
+#define BPMSG1112 bp_message_write_line(BPMSG1112_str, 14)
+void BPMSG1114_str(void);
+#define BPMSG1114 bp_message_write_line(BPMSG1114_str, 21)
+void BPMSG1115_str(void);
+#define BPMSG1115 bp_message_write_line(BPMSG1115_str, 7)
+void BPMSG1117_str(void);
+#define BPMSG1117 bp_message_write_buffer(BPMSG1117_str, 6)
+void BPMSG1118_str(void);
+#define BPMSG1118 bp_message_write_line(BPMSG1118_str, 30)
+void BPMSG1119_str(void);
+#define BPMSG1119 bp_message_write_line(BPMSG1119_str, 12)
+void BPMSG1120_str(void);
+#define BPMSG1120 bp_message_write_line(BPMSG1120_str, 34)
+void BPMSG1121_str(void);
+#define BPMSG1121 bp_message_write_line(BPMSG1121_str, 30)
+void BPMSG1123_str(void);
+#define BPMSG1123 bp_message_write_buffer(BPMSG1123_str, 27)
+void BPMSG1124_str(void);
+#define BPMSG1124 bp_message_write_buffer(BPMSG1124_str, 28)
+void BPMSG1126_str(void);
+#define BPMSG1126 bp_message_write_buffer(BPMSG1126_str, 13)
+void BPMSG1127_str(void);
+#define BPMSG1127 bp_message_write_line(BPMSG1127_str, 34)
+void BPMSG1128_str(void);
+#define BPMSG1128 bp_message_write_line(BPMSG1128_str, 18)
+void BPMSG1133_str(void);
+#define BPMSG1133 bp_message_write_line(BPMSG1133_str, 141)
+void BPMSG1134_str(void);
+#define BPMSG1134 bp_message_write_line(BPMSG1134_str, 20)
+void BPMSG1135_str(void);
+#define BPMSG1135 bp_message_write_buffer(BPMSG1135_str, 14)
+void BPMSG1136_str(void);
+#define BPMSG1136 bp_message_write_buffer(BPMSG1136_str, 5)
+void BPMSG1137_str(void);
+#define BPMSG1137 bp_message_write_buffer(BPMSG1137_str, 6)
+void BPMSG1163_str(void);
+#define BPMSG1163 bp_message_write_line(BPMSG1163_str, 63)
+void BPMSG1164_str(void);
+#define BPMSG1164 bp_message_write_line(BPMSG1164_str, 4)
+void BPMSG1165_str(void);
+#define BPMSG1165 bp_message_write_buffer(BPMSG1165_str, 3)
+void BPMSG1166_str(void);
+#define BPMSG1166 bp_message_write_buffer(BPMSG1166_str, 8)
+void BPMSG1167_str(void);
+#define BPMSG1167 bp_message_write_buffer(BPMSG1167_str, 8)
+void BPMSG1168_str(void);
+#define BPMSG1168 bp_message_write_buffer(BPMSG1168_str, 8)
+void BPMSG1169_str(void);
+#define BPMSG1169 bp_message_write_buffer(BPMSG1169_str, 4)
+void BPMSG1170_str(void);
+#define BPMSG1170 bp_message_write_line(BPMSG1170_str, 14)
+void BPMSG1171_str(void);
+#define BPMSG1171 bp_message_write_buffer(BPMSG1171_str, 2)
+void BPMSG1172_str(void);
+#define BPMSG1172 bp_message_write_buffer(BPMSG1172_str, 3)
+void BPMSG1173_str(void);
+#define BPMSG1173 bp_message_write_buffer(BPMSG1173_str, 4)
+void BPMSG1174_str(void);
+#define BPMSG1174 bp_message_write_buffer(BPMSG1174_str, 3)
+void BPMSG1175_str(void);
+#define BPMSG1175 bp_message_write_line(BPMSG1175_str, 8)
+void BPMSG1176_str(void);
+#define BPMSG1176 bp_message_write_line(BPMSG1176_str, 10)
+void BPMSG1177_str(void);
+#define BPMSG1177 bp_message_write_line(BPMSG1177_str, 10)
+void BPMSG1178_str(void);
+#define BPMSG1178 bp_message_write_line(BPMSG1178_str, 32)
+void BPMSG1179_str(void);
+#define BPMSG1179 bp_message_write_buffer(BPMSG1179_str, 6)
+void BPMSG1180_str(void);
+#define BPMSG1180 bp_message_write_line(BPMSG1180_str, 8)
+void BPMSG1181_str(void);
+#define BPMSG1181 bp_message_write_buffer(BPMSG1181_str, 4)
+void BPMSG1182_str(void);
+#define BPMSG1182 bp_message_write_buffer(BPMSG1182_str, 3)
+void BPMSG1183_str(void);
+#define BPMSG1183 bp_message_write_buffer(BPMSG1183_str, 4)
+void BPMSG1184_str(void);
+#define BPMSG1184 bp_message_write_buffer(BPMSG1184_str, 2)
+void BPMSG1185_str(void);
+#define BPMSG1185 bp_message_write_line(BPMSG1185_str, 3)
+void BPMSG1186_str(void);
+#define BPMSG1186 bp_message_write_line(BPMSG1186_str, 5)
+void BPMSG1187_str(void);
+#define BPMSG1187 bp_message_write_line(BPMSG1187_str, 154)
+void BPMSG1188_str(void);
+#define BPMSG1188 bp_message_write_line(BPMSG1188_str, 53)
+void BPMSG1189_str(void);
+#define BPMSG1189 bp_message_write_line(BPMSG1189_str, 67)
+void BPMSG1190_str(void);
+#define BPMSG1190 bp_message_write_line(BPMSG1190_str, 49)
+void BPMSG1191_str(void);
+#define BPMSG1191 bp_message_write_buffer(BPMSG1191_str, 32)
+void BPMSG1192_str(void);
+#define BPMSG1192 bp_message_write_line(BPMSG1192_str, 52)
+void BPMSG1194_str(void);
+#define BPMSG1194 bp_message_write_buffer(BPMSG1194_str, 3)
+void BPMSG1195_str(void);
+#define BPMSG1195 bp_message_write_buffer(BPMSG1195_str, 3)
+void BPMSG1196_str(void);
+#define BPMSG1196 bp_message_write_buffer(BPMSG1196_str, 15)
+void BPMSG1197_str(void);
+#define BPMSG1197 bp_message_write_buffer(BPMSG1197_str, 15)
+void BPMSG1199_str(void);
+#define BPMSG1199 bp_message_write_buffer(BPMSG1199_str, 84)
+void BPMSG1200_str(void);
+#define BPMSG1200 bp_message_write_buffer(BPMSG1200_str, 33)
+void BPMSG1201_str(void);
+#define BPMSG1201 bp_message_write_buffer(BPMSG1201_str, 50)
+void BPMSG1202_str(void);
+#define BPMSG1202 bp_message_write_buffer(BPMSG1202_str, 32)
+void BPMSG1203_str(void);
+#define BPMSG1203 bp_message_write_buffer(BPMSG1203_str, 106)
+void BPMSG1204_str(void);
+#define BPMSG1204 bp_message_write_line(BPMSG1204_str, 11)
+void BPMSG1206_str(void);
+#define BPMSG1206 bp_message_write_line(BPMSG1206_str, 14)
+void BPMSG1207_str(void);
+#define BPMSG1207 bp_message_write_line(BPMSG1207_str, 28)
+void BPMSG1208_str(void);
+#define BPMSG1208 bp_message_write_line(BPMSG1208_str, 20)
+void BPMSG1209_str(void);
+#define BPMSG1209 bp_message_write_line(BPMSG1209_str, 34)
+void BPMSG1210_str(void);
+#define BPMSG1210 bp_message_write_buffer(BPMSG1210_str, 7)
+void BPMSG1211_str(void);
+#define BPMSG1211 bp_message_write_line(BPMSG1211_str, 27)
+void BPMSG1212_str(void);
+#define BPMSG1212 bp_message_write_line(BPMSG1212_str, 2)
+void BPMSG1213_str(void);
+#define BPMSG1213 bp_message_write_line(BPMSG1213_str, 20)
+void BPMSG1214_str(void);
+#define BPMSG1214 bp_message_write_line(BPMSG1214_str, 18)
+void BPMSG1216_str(void);
+#define BPMSG1216 bp_message_write_line(BPMSG1216_str, 29)
+void BPMSG1219_str(void);
+#define BPMSG1219 bp_message_write_line(BPMSG1219_str, 152)
+void BPMSG1220_str(void);
+#define BPMSG1220 bp_message_write_line(BPMSG1220_str, 36)
+void BPMSG1221_str(void);
+#define BPMSG1221 bp_message_write_line(BPMSG1221_str, 4)
+void BPMSG1222_str(void);
+#define BPMSG1222 bp_message_write_line(BPMSG1222_str, 5)
+void BPMSG1223_str(void);
+#define BPMSG1223 bp_message_write_line(BPMSG1223_str, 10)
+void BPMSG1226_str(void);
+#define BPMSG1226 bp_message_write_line(BPMSG1226_str, 10)
+void BPMSG1227_str(void);
+#define BPMSG1227 bp_message_write_buffer(BPMSG1227_str, 26)
+void BPMSG1228_str(void);
+#define BPMSG1228 bp_message_write_buffer(BPMSG1228_str, 10)
+void BPMSG1229_str(void);
+#define BPMSG1229 bp_message_write_line(BPMSG1229_str, 9)
+void BPMSG1232_str(void);
+#define BPMSG1232 bp_message_write_line(BPMSG1232_str, 11)
+void BPMSG1233_str(void);
+#define BPMSG1233 bp_message_write_line(BPMSG1233_str, 70)
+void BPMSG1234_str(void);
+#define BPMSG1234 bp_message_write_buffer(BPMSG1234_str, 4)
+void BPMSG1237_str(void);
+#define BPMSG1237 bp_message_write_buffer(BPMSG1237_str, 8)
+void BPMSG1238_str(void);
+#define BPMSG1238 bp_message_write_line(BPMSG1238_str, 38)
+void BPMSG1239_str(void);
+#define BPMSG1239 bp_message_write_line(BPMSG1239_str, 28)
+void BPMSG1240_str(void);
+#define BPMSG1240 bp_message_write_line(BPMSG1240_str, 16)
+void BPMSG1241_str(void);
+#define BPMSG1241 bp_message_write_line(BPMSG1241_str, 14)
+void BPMSG1242_str(void);
+#define BPMSG1242 bp_message_write_line(BPMSG1242_str, 15)
+void BPMSG1243_str(void);
+#define BPMSG1243 bp_message_write_line(BPMSG1243_str, 5)
+void BPMSG1244_str(void);
+#define BPMSG1244 bp_message_write_line(BPMSG1244_str, 14)
+void BPMSG1245_str(void);
+#define BPMSG1245 bp_message_write_buffer(BPMSG1245_str, 11)
+void BPMSG1248_str(void);
+#define BPMSG1248 bp_message_write_line(BPMSG1248_str, 28)
+void BPMSG1250_str(void);
+#define BPMSG1250 bp_message_write_line(BPMSG1250_str, 15)
+void BPMSG1251_str(void);
+#define BPMSG1251 bp_message_write_line(BPMSG1251_str, 17)
+void BPMSG1252_str(void);
+#define BPMSG1252 bp_message_write_buffer(BPMSG1252_str, 27)
+void BPMSG1254_str(void);
+#define BPMSG1254 bp_message_write_line(BPMSG1254_str, 19)
+void BPMSG1255_str(void);
+#define BPMSG1255 bp_message_write_line(BPMSG1255_str, 12)
+void BPMSG1280_str(void);
+#define BPMSG1280 bp_message_write_line(BPMSG1280_str, 19)
+void BPMSG1281_str(void);
+#define BPMSG1281 bp_message_write_line(BPMSG1281_str, 14)
+void BPMSG1282_str(void);
+#define BPMSG1282 bp_message_write_line(BPMSG1282_str, 47)
+void BPMSG1283_str(void);
+#define BPMSG1283 bp_message_write_buffer(BPMSG1283_str, 15)
+void BPMSG1284_str(void);
+#define BPMSG1284 bp_message_write_buffer(BPMSG1284_str, 15)
+void BPMSG1285_str(void);
+#define BPMSG1285 bp_message_write_line(BPMSG1285_str, 4)
+void HLP1000_str(void);
+#define HLP1000 bp_message_write_line(HLP1000_str, 33)
+void HLP1001_str(void);
+#define HLP1001 bp_message_write_line(HLP1001_str, 76)
+void HLP1002_str(void);
+#define HLP1002 bp_message_write_line(HLP1002_str, 38)
+void HLP1003_str(void);
+#define HLP1003 bp_message_write_line(HLP1003_str, 40)
+void HLP1004_str(void);
+#define HLP1004 bp_message_write_line(HLP1004_str, 21)
+void HLP1005_str(void);
+#define HLP1005 bp_message_write_line(HLP1005_str, 27)
+void HLP1006_str(void);
+#define HLP1006 bp_message_write_line(HLP1006_str, 40)
+void HLP1007_str(void);
+#define HLP1007 bp_message_write_line(HLP1007_str, 27)
+void HLP1008_str(void);
+#define HLP1008 bp_message_write_line(HLP1008_str, 46)
+void HLP1009_str(void);
+#define HLP1009 bp_message_write_line(HLP1009_str, 21)
+void HLP1010_str(void);
+#define HLP1010 bp_message_write_line(HLP1010_str, 35)
+void HLP1011_str(void);
+#define HLP1011 bp_message_write_line(HLP1011_str, 46)
+void HLP1012_str(void);
+#define HLP1012 bp_message_write_line(HLP1012_str, 28)
+void HLP1013_str(void);
+#define HLP1013 bp_message_write_line(HLP1013_str, 33)
+void HLP1014_str(void);
+#define HLP1014 bp_message_write_line(HLP1014_str, 28)
+void HLP1015_str(void);
+#define HLP1015 bp_message_write_line(HLP1015_str, 37)
+void HLP1016_str(void);
+#define HLP1016 bp_message_write_line(HLP1016_str, 33)
+void HLP1017_str(void);
+#define HLP1017 bp_message_write_line(HLP1017_str, 25)
+void HLP1018_str(void);
+#define HLP1018 bp_message_write_line(HLP1018_str, 31)
+void HLP1019_str(void);
+#define HLP1019 bp_message_write_line(HLP1019_str, 41)
+void HLP1020_str(void);
+#define HLP1020 bp_message_write_line(HLP1020_str, 37)
+void HLP1021_str(void);
+#define HLP1021 bp_message_write_line(HLP1021_str, 54)
+void HLP1022_str(void);
+#define HLP1022 bp_message_write_line(HLP1022_str, 62)
+void MSG_1WIRE_MODE_IDENTIFIER_str(void);
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(MSG_1WIRE_MODE_IDENTIFIER_str, 4)
+void MSG_1WIRE_SPEED_PROMPT_str(void);
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(MSG_1WIRE_SPEED_PROMPT_str, 62)
+void MSG_ACK_str(void);
+#define MSG_ACK bp_message_write_buffer(MSG_ACK_str, 3)
+void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(MSG_BASE_CONVERTER_EQUAL_SIGN_str, 3)
+void MSG_BBIO_MODE_IDENTIFIER_str(void);
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(MSG_BBIO_MODE_IDENTIFIER_str, 5)
+void MSG_BINARY_NUMBER_PREFIX_str(void);
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(MSG_BINARY_NUMBER_PREFIX_str, 2)
+void MSG_CHIP_IDENTIFIER_CLONE_str(void);
+#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(MSG_CHIP_IDENTIFIER_CLONE_str, 22)
+void MSG_CHIP_REVISION_A3_str(void);
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(MSG_CHIP_REVISION_A3_str, 2)
+void MSG_CHIP_REVISION_B4_str(void);
+#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(MSG_CHIP_REVISION_B4_str, 2)
+void MSG_CHIP_REVISION_B5_str(void);
+#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(MSG_CHIP_REVISION_B5_str, 2)
+void MSG_CHIP_REVISION_B8_str(void);
+#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(MSG_CHIP_REVISION_B8_str, 2)
+void MSG_CHIP_REVISION_ID_BEGIN_str(void);
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(MSG_CHIP_REVISION_ID_BEGIN_str, 13)
+void MSG_CHIP_REVISION_ID_END_2_str(void);
+#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(MSG_CHIP_REVISION_ID_END_2_str, 2)
+void MSG_CHIP_REVISION_ID_END_4_str(void);
+#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(MSG_CHIP_REVISION_ID_END_4_str, 2)
+void MSG_CHIP_REVISION_UNKNOWN_str(void);
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(MSG_CHIP_REVISION_UNKNOWN_str, 3)
+void MSG_CLUTCH_DISENGAGED_str(void);
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(MSG_CLUTCH_DISENGAGED_str, 20)
+void MSG_CLUTCH_ENGAGED_str(void);
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(MSG_CLUTCH_ENGAGED_str, 17)
+void MSG_FINISH_SETUP_PROMPT_str(void);
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(MSG_FINISH_SETUP_PROMPT_str, 61)
+void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(MSG_HEXADECIMAL_NUMBER_PREFIX_str, 2)
+void MSG_I2C_MODE_IDENTIFIER_str(void);
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(MSG_I2C_MODE_IDENTIFIER_str, 4)
+void MSG_I2C_PINS_STATE_str(void);
+#define MSG_I2C_PINS_STATE bp_message_write_line(MSG_I2C_PINS_STATE_str, 11)
+void MSG_I2C_READ_ADDRESS_END_str(void);
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(MSG_I2C_READ_ADDRESS_END_str, 4)
+void MSG_I2C_START_BIT_str(void);
+#define MSG_I2C_START_BIT bp_message_write_line(MSG_I2C_START_BIT_str, 13)
+void MSG_I2C_STOP_BIT_str(void);
+#define MSG_I2C_STOP_BIT bp_message_write_line(MSG_I2C_STOP_BIT_str, 12)
+void MSG_I2C_WRITE_ADDRESS_END_str(void);
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(MSG_I2C_WRITE_ADDRESS_END_str, 4)
+void MSG_MODE_HEADER_END_str(void);
+#define MSG_MODE_HEADER_END bp_message_write_line(MSG_MODE_HEADER_END_str, 2)
+void MSG_NACK_str(void);
+#define MSG_NACK bp_message_write_buffer(MSG_NACK_str, 4)
+void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str, 34)
+void MSG_OPENOCD_MODE_IDENTIFIER_str(void);
+#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(MSG_OPENOCD_MODE_IDENTIFIER_str, 4)
+void MSG_PIC_MODE_IDENTIFIER_str(void);
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(MSG_PIC_MODE_IDENTIFIER_str, 4)
+void MSG_PIC_UNKNOWN_MODE_str(void);
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(MSG_PIC_UNKNOWN_MODE_str, 12)
+void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(MSG_PIN_OUTPUT_TYPE_PROMPT_str, 79)
+void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(MSG_PWM_FREQUENCY_TOO_LOW_str, 36)
+void MSG_PWM_HZ_MARKER_str(void);
+#define MSG_PWM_HZ_MARKER bp_message_write_line(MSG_PWM_HZ_MARKER_str, 3)
+void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str, 12)
+void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str, 13)
+void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str, 25)
+void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str, 10)
+void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str, 7)
+void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str, 11)
+void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str, 6)
+void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str, 15)
+void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_REPLY_HEADER_str, 45)
+void MSG_RAW2WIRE_ATR_RFU_str(void);
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(MSG_RAW2WIRE_ATR_RFU_str, 3)
+void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str, 63)
+void MSG_RAW2WIRE_I2C_START_str(void);
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(MSG_RAW2WIRE_I2C_START_str, 8)
+void MSG_RAW2WIRE_I2C_STOP_str(void);
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(MSG_RAW2WIRE_I2C_STOP_str, 6)
+void MSG_RAW2WIRE_MACRO_MENU_str(void);
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(MSG_RAW2WIRE_MACRO_MENU_str, 56)
+void MSG_RAW2WIRE_MODE_HEADER_str(void);
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_MODE_HEADER_str, 16)
+void MSG_RAW3WIRE_MODE_HEADER_str(void);
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW3WIRE_MODE_HEADER_str, 20)
+void MSG_RAW_BRG_VALUE_INPUT_str(void);
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(MSG_RAW_BRG_VALUE_INPUT_str, 23)
+void MSG_RAW_MODE_IDENTIFIER_str(void);
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(MSG_RAW_MODE_IDENTIFIER_str, 4)
+void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(MSG_SOFTWARE_MODE_SPEED_PROMPT_str, 59)
+void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(MSG_SPI_COULD_NOT_KEEP_UP_str, 16)
+void MSG_SPI_CS_DISABLED_str(void);
+#define MSG_SPI_CS_DISABLED bp_message_write_line(MSG_SPI_CS_DISABLED_str, 11)
+void MSG_SPI_CS_ENABLED_str(void);
+#define MSG_SPI_CS_ENABLED bp_message_write_line(MSG_SPI_CS_ENABLED_str, 10)
+void MSG_SPI_CS_MODE_PROMPT_str(void);
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(MSG_SPI_CS_MODE_PROMPT_str, 29)
+void MSG_SPI_MODE_IDENTIFIER_str(void);
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(MSG_SPI_MODE_IDENTIFIER_str, 4)
+void MSG_SPI_PINS_STATE_str(void);
+#define MSG_SPI_PINS_STATE bp_message_write_line(MSG_SPI_PINS_STATE_str, 16)
+void MSG_UART_MODE_IDENTIFIER_str(void);
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(MSG_UART_MODE_IDENTIFIER_str, 4)
+void MSG_UART_PINS_STATE_str(void);
+#define MSG_UART_PINS_STATE bp_message_write_line(MSG_UART_PINS_STATE_str, 11)
+void MSG_UART_POSSIBLE_OVERFLOW_str(void);
+#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(MSG_UART_POSSIBLE_OVERFLOW_str, 33)
+void MSG_UART_RESET_TO_EXIT_str(void);
+#define MSG_UART_RESET_TO_EXIT bp_message_write_line(MSG_UART_RESET_TO_EXIT_str, 13)
+void MSG_UNKNOWN_MACRO_ERROR_str(void);
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(MSG_UNKNOWN_MACRO_ERROR_str, 36)
+void MSG_VREG_TOO_LOW_str(void);
+#define MSG_VREG_TOO_LOW bp_message_write_line(MSG_VREG_TOO_LOW_str, 31)
 
 #endif /* BP_MESSAGES_V3_H */

--- a/Firmware/messages_v3.s
+++ b/Firmware/messages_v3.s
@@ -1,847 +1,1686 @@
-.global _bp_messages
-
-_bp_messages:
-
 	; BPMSG1001
+	.section .text.BPMSG1001, code
+	.global _BPMSG1001_str
+_BPMSG1001_str:
 	.pascii " *next clock (^) will use this value"
 
 	; BPMSG1004
+	.section .text.BPMSG1004, code
+	.global _BPMSG1004_str
+_BPMSG1004_str:
 	.pascii "No device, try (ALARM) SEARCH macro first"
 
 	; BPMSG1005
+	.section .text.BPMSG1005, code
+	.global _BPMSG1005_str
+_BPMSG1005_str:
 	.pascii "ADDRESS MACRO "
 
 	; BPMSG1006
+	.section .text.BPMSG1006, code
+	.global _BPMSG1006_str
+_BPMSG1006_str:
 	.pascii " 0.Macro menu"
 
 	; BPMSG1007
+	.section .text.BPMSG1007, code
+	.global _BPMSG1007_str
+_BPMSG1007_str:
 	.pascii "Macro     1WIRE address"
 
 	; BPMSG1008
+	.section .text.BPMSG1008, code
+	.global _BPMSG1008_str
+_BPMSG1008_str:
 	.pascii "\r\n   *"
 
 	; BPMSG1009
+	.section .text.BPMSG1009, code
+	.global _BPMSG1009_str
+_BPMSG1009_str:
 	.pascii "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
 
 	; BPMSG1010
+	.section .text.BPMSG1010, code
+	.global _BPMSG1010_str
+_BPMSG1010_str:
 	.pascii "ALARM SEARCH (0xEC)"
 
 	; BPMSG1011
+	.section .text.BPMSG1011, code
+	.global _BPMSG1011_str
+_BPMSG1011_str:
 	.pascii "SEARCH (0xF0)"
 
 	; BPMSG1012
+	.section .text.BPMSG1012, code
+	.global _BPMSG1012_str
+_BPMSG1012_str:
 	.pascii "Device IDs are available by MACRO, see (0)."
 
 	; BPMSG1013
+	.section .text.BPMSG1013, code
+	.global _BPMSG1013_str
+_BPMSG1013_str:
 	.pascii "READ ROM (0x33): "
 
 	; BPMSG1014
+	.section .text.BPMSG1014, code
+	.global _BPMSG1014_str
+_BPMSG1014_str:
 	.pascii "MATCH ROM (0x55)"
 
 	; BPMSG1015
+	.section .text.BPMSG1015, code
+	.global _BPMSG1015_str
+_BPMSG1015_str:
 	.pascii "SKIP ROM (0xCC)"
 
 	; BPMSG1017
+	.section .text.BPMSG1017, code
+	.global _BPMSG1017_str
+_BPMSG1017_str:
 	.pascii "BUS RESET "
 
 	; BPMSG1019
+	.section .text.BPMSG1019, code
+	.global _BPMSG1019_str
+_BPMSG1019_str:
 	.pascii "Warning: "
 
 	; BPMSG1020
+	.section .text.BPMSG1020, code
+	.global _BPMSG1020_str
+_BPMSG1020_str:
 	.pascii "*Short or no pull-up "
 
 	; BPMSG1021
+	.section .text.BPMSG1021, code
+	.global _BPMSG1021_str
+_BPMSG1021_str:
 	.pascii "*No device detected "
 
 	; BPMSG1022
+	.section .text.BPMSG1022, code
+	.global _BPMSG1022_str
+_BPMSG1022_str:
 	.pascii "DS18S20 High Pres Dig Therm"
 
 	; BPMSG1023
+	.section .text.BPMSG1023, code
+	.global _BPMSG1023_str
+_BPMSG1023_str:
 	.pascii "DS18B20 Prog Res Dig Therm"
 
 	; BPMSG1024
+	.section .text.BPMSG1024, code
+	.global _BPMSG1024_str
+_BPMSG1024_str:
 	.pascii "DS1822 Econ Dig Therm"
 
 	; BPMSG1025
+	.section .text.BPMSG1025, code
+	.global _BPMSG1025_str
+_BPMSG1025_str:
 	.pascii "DS2404 Econram time Chip"
 
 	; BPMSG1026
+	.section .text.BPMSG1026, code
+	.global _BPMSG1026_str
+_BPMSG1026_str:
 	.pascii "DS2431 1K EEPROM"
 
 	; BPMSG1027
+	.section .text.BPMSG1027, code
+	.global _BPMSG1027_str
+_BPMSG1027_str:
 	.pascii "Unknown device"
 
 	; BPMSG1028
+	.section .text.BPMSG1028, code
+	.global _BPMSG1028_str
+_BPMSG1028_str:
 	.pascii "PWM disabled"
 
 	; BPMSG1029
+	.section .text.BPMSG1029, code
+	.global _BPMSG1029_str
+_BPMSG1029_str:
 	.pascii "1KHz-4,000KHz PWM"
 
 	; BPMSG1030
+	.section .text.BPMSG1030, code
+	.global _BPMSG1030_str
+_BPMSG1030_str:
 	.pascii "Frequency in KHz "
 
 	; BPMSG1033
+	.section .text.BPMSG1033, code
+	.global _BPMSG1033_str
+_BPMSG1033_str:
 	.pascii "Duty cycle in % "
 
 	; BPMSG1034
+	.section .text.BPMSG1034, code
+	.global _BPMSG1034_str
+_BPMSG1034_str:
 	.pascii "PWM active"
 
 	; BPMSG1037
+	.section .text.BPMSG1037, code
+	.global _BPMSG1037_str
+_BPMSG1037_str:
 	.pascii "ERROR: PWM active, g to disable"
 
 	; BPMSG1038
+	.section .text.BPMSG1038, code
+	.global _BPMSG1038_str
+_BPMSG1038_str:
 	.pascii "AUX Frequency: "
 
 	; BPMSG1039
+	.section .text.BPMSG1039, code
+	.global _BPMSG1039_str
+_BPMSG1039_str:
 	.pascii "AUX INPUT/HI-Z"
 
 	; BPMSG1040
+	.section .text.BPMSG1040, code
+	.global _BPMSG1040_str
+_BPMSG1040_str:
 	.pascii "AUX HIGH"
 
 	; BPMSG1041
+	.section .text.BPMSG1041, code
+	.global _BPMSG1041_str
+_BPMSG1041_str:
 	.pascii "AUX LOW"
 
 	; BPMSG1042
+	.section .text.BPMSG1042, code
+	.global _BPMSG1042_str
+_BPMSG1042_str:
 	.pascii "VOLTMETER MODE"
 
 	; BPMSG1044
+	.section .text.BPMSG1044, code
+	.global _BPMSG1044_str
+_BPMSG1044_str:
 	.pascii "VOLTAGE PROBE: "
 
 	; BPMSG1045
+	.section .text.BPMSG1045, code
+	.global _BPMSG1045_str
+_BPMSG1045_str:
 	.pascii "V"
 
 	; BPMSG1047
+	.section .text.BPMSG1047, code
+	.global _BPMSG1047_str
+_BPMSG1047_str:
 	.pascii "Error("
 
 	; BPMSG1048
+	.section .text.BPMSG1048, code
+	.global _BPMSG1048_str
+_BPMSG1048_str:
 	.pascii ") @line:"
 
 	; BPMSG1049
+	.section .text.BPMSG1049, code
+	.global _BPMSG1049_str
+_BPMSG1049_str:
 	.pascii " @pgmspace:"
 
 	; BPMSG1050
+	.section .text.BPMSG1050, code
+	.global _BPMSG1050_str
+_BPMSG1050_str:
 	.pascii " bytes."
 
 	; BPMSG1051
+	.section .text.BPMSG1051, code
+	.global _BPMSG1051_str
+_BPMSG1051_str:
 	.pascii "Too long!"
 
 	; BPMSG1052
+	.section .text.BPMSG1052, code
+	.global _BPMSG1052_str
+_BPMSG1052_str:
 	.pascii "Syntax error"
 
 	; BPMSG1059
+	.section .text.BPMSG1059, code
+	.global _BPMSG1059_str
+_BPMSG1059_str:
 	.pascii "ERROR: command has no effect here"
 
 	; BPMSG1064
+	.section .text.BPMSG1064, code
+	.global _BPMSG1064_str
+_BPMSG1064_str:
 	.pascii "I2C mode:\r\n 1. Software\r\n 2. Hardware"
 
 	; BPMSG1066
+	.section .text.BPMSG1066, code
+	.global _BPMSG1066_str
+_BPMSG1066_str:
 	.pascii "WARNING: HARDWARE I2C is broken on this PIC! (REV A3)"
 
 	; BPMSG1067
+	.section .text.BPMSG1067, code
+	.global _BPMSG1067_str
+_BPMSG1067_str:
 	.pascii "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
 
 	; BPMSG1068
+	.section .text.BPMSG1068, code
+	.global _BPMSG1068_str
+_BPMSG1068_str:
 	.pascii "I2C (mod spd)=( "
 
 	; BPMSG1069
+	.section .text.BPMSG1069, code
+	.global _BPMSG1069_str
+_BPMSG1069_str:
 	.pascii " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer"
 
 	; BPMSG1070
+	.section .text.BPMSG1070, code
+	.global _BPMSG1070_str
+_BPMSG1070_str:
 	.pascii "Searching I2C address space. Found devices at:"
 
 	; BPMSG1071
+	.section .text.BPMSG1071, code
+	.global _BPMSG1071_str
+_BPMSG1071_str:
 	.pascii "Sniffer"
 
 	; BPMSG1072
+	.section .text.BPMSG1072, code
+	.global _BPMSG1072_str
+_BPMSG1072_str:
 	.pascii "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
 
 	; BPMSG1073
+	.section .text.BPMSG1073, code
+	.global _BPMSG1073_str
+_BPMSG1073_str:
 	.pascii "Delay?"
 
 	; BPMSG1074
+	.section .text.BPMSG1074, code
+	.global _BPMSG1074_str
+_BPMSG1074_str:
 	.pascii "PIC(mod dly)=("
 
 	; BPMSG1075
+	.section .text.BPMSG1075, code
+	.global _BPMSG1075_str
+_BPMSG1075_str:
 	.pascii "CMD"
 
 	; BPMSG1076
+	.section .text.BPMSG1076, code
+	.global _BPMSG1076_str
+_BPMSG1076_str:
 	.pascii "DTA"
 
 	; BPMSG1077
+	.section .text.BPMSG1077, code
+	.global _BPMSG1077_str
+_BPMSG1077_str:
 	.pascii "no read"
 
 	; BPMSG1078
+	.section .text.BPMSG1078, code
+	.global _BPMSG1078_str
+_BPMSG1078_str:
 	.pascii "unknown mode"
 
 	; BPMSG1079
+	.section .text.BPMSG1079, code
+	.global _BPMSG1079_str
+_BPMSG1079_str:
 	.pascii "(1) get devID"
 
 	; BPMSG1080
+	.section .text.BPMSG1080, code
+	.global _BPMSG1080_str
+_BPMSG1080_str:
 	.pascii "DevID = "
 
 	; BPMSG1081
+	.section .text.BPMSG1081, code
+	.global _BPMSG1081_str
+_BPMSG1081_str:
 	.pascii " Rev = "
 
 	; BPMSG1082
+	.section .text.BPMSG1082, code
+	.global _BPMSG1082_str
+_BPMSG1082_str:
 	.pascii "Not implemented (yet)"
 
 	; BPMSG1083
+	.section .text.BPMSG1083, code
+	.global _BPMSG1083_str
+_BPMSG1083_str:
 	.pascii "Please exit PIC programming mode"
 
 	; BPMSG1084
+	.section .text.BPMSG1084, code
+	.global _BPMSG1084_str
+_BPMSG1084_str:
 	.pascii "(BASIC)"
 
 	; BPMSG1085
+	.section .text.BPMSG1085, code
+	.global _BPMSG1085_str
+_BPMSG1085_str:
 	.pascii "Ready"
 
 	; BPMSG1086
+	.section .text.BPMSG1086, code
+	.global _BPMSG1086_str
+_BPMSG1086_str:
 	.pascii "a/A/@ controls AUX pin"
 
 	; BPMSG1087
+	.section .text.BPMSG1087, code
+	.global _BPMSG1087_str
+_BPMSG1087_str:
 	.pascii "a/A/@ controls CS pin"
 
 	; BPMSG1088
+	.section .text.BPMSG1088, code
+	.global _BPMSG1088_str
+_BPMSG1088_str:
 	.pascii "Command not used in this mode"
 
 	; BPMSG1089
+	.section .text.BPMSG1089, code
+	.global _BPMSG1089_str
+_BPMSG1089_str:
 	.pascii "Pull-up resistors OFF"
 
 	; BPMSG1091
+	.section .text.BPMSG1091, code
+	.global _BPMSG1091_str
+_BPMSG1091_str:
 	.pascii "Pull-up resistors ON"
 
 	; BPMSG1092
+	.section .text.BPMSG1092, code
+	.global _BPMSG1092_str
+_BPMSG1092_str:
 	.pascii "Self-test in HiZ mode only"
 
 	; BPMSG1093
+	.section .text.BPMSG1093, code
+	.global _BPMSG1093_str
+_BPMSG1093_str:
 	.pascii "RESET"
 
 	; BPMSG1094
+	.section .text.BPMSG1094, code
+	.global _BPMSG1094_str
+_BPMSG1094_str:
 	.pascii "BOOTLOADER"
 
 	; BPMSG1095
+	.section .text.BPMSG1095, code
+	.global _BPMSG1095_str
+_BPMSG1095_str:
 	.pascii "AUX INPUT/HI-Z, READ: "
 
 	; BPMSG1096
+	.section .text.BPMSG1096, code
+	.global _BPMSG1096_str
+_BPMSG1096_str:
 	.pascii "POWER SUPPLIES ON"
 
 	; BPMSG1097
+	.section .text.BPMSG1097, code
+	.global _BPMSG1097_str
+_BPMSG1097_str:
 	.pascii "POWER SUPPLIES OFF"
 
 	; BPMSG1098
+	.section .text.BPMSG1098, code
+	.global _BPMSG1098_str
+_BPMSG1098_str:
 	.pascii "DATA STATE: "
 
 	; BPMSG1099
+	.section .text.BPMSG1099, code
+	.global _BPMSG1099_str
+_BPMSG1099_str:
 	.pascii "DELAY "
 
 	; BPMSG1100
+	.section .text.BPMSG1100, code
+	.global _BPMSG1100_str
+_BPMSG1100_str:
 	.pascii "us"
 
 	; BPMSG1101
+	.section .text.BPMSG1101, code
+	.global _BPMSG1101_str
+_BPMSG1101_str:
 	.pascii "WRITE: "
 
 	; BPMSG1102
+	.section .text.BPMSG1102, code
+	.global _BPMSG1102_str
+_BPMSG1102_str:
 	.pascii "READ: "
 
 	; BPMSG1103
+	.section .text.BPMSG1103, code
+	.global _BPMSG1103_str
+_BPMSG1103_str:
 	.pascii "CLOCK, 1"
 
 	; BPMSG1104
+	.section .text.BPMSG1104, code
+	.global _BPMSG1104_str
+_BPMSG1104_str:
 	.pascii "CLOCK, 0"
 
 	; BPMSG1105
+	.section .text.BPMSG1105, code
+	.global _BPMSG1105_str
+_BPMSG1105_str:
 	.pascii "DATA OUTPUT, 1"
 
 	; BPMSG1106
+	.section .text.BPMSG1106, code
+	.global _BPMSG1106_str
+_BPMSG1106_str:
 	.pascii "DATA OUTPUT, 0"
 
 	; BPMSG1107
+	.section .text.BPMSG1107, code
+	.global _BPMSG1107_str
+_BPMSG1107_str:
 	.pascii " *pin is now HiZ"
 
 	; BPMSG1108
+	.section .text.BPMSG1108, code
+	.global _BPMSG1108_str
+_BPMSG1108_str:
 	.pascii "CLOCK TICKS: "
 
 	; BPMSG1109
+	.section .text.BPMSG1109, code
+	.global _BPMSG1109_str
+_BPMSG1109_str:
 	.pascii "READ BIT: "
 
 	; BPMSG1110
+	.section .text.BPMSG1110, code
+	.global _BPMSG1110_str
+_BPMSG1110_str:
 	.pascii "Syntax error at char "
 
 	; BPMSG1111
+	.section .text.BPMSG1111, code
+	.global _BPMSG1111_str
+_BPMSG1111_str:
 	.pascii "x. exit(without change)"
 
 	; BPMSG1112
+	.section .text.BPMSG1112, code
+	.global _BPMSG1112_str
+_BPMSG1112_str:
 	.pascii "no mode change"
 
 	; BPMSG1114
+	.section .text.BPMSG1114, code
+	.global _BPMSG1114_str
+_BPMSG1114_str:
 	.pascii "Nonexistent protocol!"
 
 	; BPMSG1115
+	.section .text.BPMSG1115, code
+	.global _BPMSG1115_str
+_BPMSG1115_str:
 	.pascii "x. exit"
 
 	; BPMSG1117
+	.section .text.BPMSG1117, code
+	.global _BPMSG1117_str
+_BPMSG1117_str:
 	.pascii "DEVID:"
 
 	; BPMSG1118
+	.section .text.BPMSG1118, code
+	.global _BPMSG1118_str
+_BPMSG1118_str:
 	.pascii "http://dangerousprototypes.com"
 
 	; BPMSG1119
+	.section .text.BPMSG1119, code
+	.global _BPMSG1119_str
+_BPMSG1119_str:
 	.pascii "*----------*"
 
 	; BPMSG1120
+	.section .text.BPMSG1120, code
+	.global _BPMSG1120_str
+_BPMSG1120_str:
 	.pascii "Open drain outputs (H=Hi-Z, L=GND)"
 
 	; BPMSG1121
+	.section .text.BPMSG1121, code
+	.global _BPMSG1121_str
+_BPMSG1121_str:
 	.pascii "Normal outputs (H=3.3v, L=GND)"
 
 	; BPMSG1123
+	.section .text.BPMSG1123, code
+	.global _BPMSG1123_str
+_BPMSG1123_str:
 	.pascii "MSB set: MOST sig bit first"
 
 	; BPMSG1124
+	.section .text.BPMSG1124, code
+	.global _BPMSG1124_str
+_BPMSG1124_str:
 	.pascii "LSB set: LEAST sig bit first"
 
 	; BPMSG1126
+	.section .text.BPMSG1126, code
+	.global _BPMSG1126_str
+_BPMSG1126_str:
 	.pascii " Bootloader v"
 
 	; BPMSG1127
+	.section .text.BPMSG1127, code
+	.global _BPMSG1127_str
+_BPMSG1127_str:
 	.pascii " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
 
 	; BPMSG1128
+	.section .text.BPMSG1128, code
+	.global _BPMSG1128_str
+_BPMSG1128_str:
 	.pascii "Display format set"
 
 	; BPMSG1133
+	.section .text.BPMSG1133, code
+	.global _BPMSG1133_str
+_BPMSG1133_str:
 	.pascii "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. BRG raw value"
 
 	; BPMSG1134
+	.section .text.BPMSG1134, code
+	.global _BPMSG1134_str
+_BPMSG1134_str:
 	.pascii "Adjust your terminal"
 
 	; BPMSG1135
+	.section .text.BPMSG1135, code
+	.global _BPMSG1135_str
+_BPMSG1135_str:
 	.pascii "Are you sure? "
 
 	; BPMSG1136
+	.section .text.BPMSG1136, code
+	.global _BPMSG1136_str
+_BPMSG1136_str:
 	.pascii "CFG1:"
 
 	; BPMSG1137
+	.section .text.BPMSG1137, code
+	.global _BPMSG1137_str
+_BPMSG1137_str:
 	.pascii " CFG2:"
 
 	; BPMSG1163
+	.section .text.BPMSG1163, code
+	.global _BPMSG1163_str
+_BPMSG1163_str:
 	.pascii "Disconnect any devices\r\nConnect (Vpu to +5V) and (ADC to +3.3V)"
 
 	; BPMSG1164
+	.section .text.BPMSG1164, code
+	.global _BPMSG1164_str
+_BPMSG1164_str:
 	.pascii "Ctrl"
 
 	; BPMSG1165
+	.section .text.BPMSG1165, code
+	.global _BPMSG1165_str
+_BPMSG1165_str:
 	.pascii "AUX"
 
 	; BPMSG1166
+	.section .text.BPMSG1166, code
+	.global _BPMSG1166_str
+_BPMSG1166_str:
 	.pascii "MODE LED"
 
 	; BPMSG1167
+	.section .text.BPMSG1167, code
+	.global _BPMSG1167_str
+_BPMSG1167_str:
 	.pascii "PULLUP H"
 
 	; BPMSG1168
+	.section .text.BPMSG1168, code
+	.global _BPMSG1168_str
+_BPMSG1168_str:
 	.pascii "PULLUP L"
 
 	; BPMSG1169
+	.section .text.BPMSG1169, code
+	.global _BPMSG1169_str
+_BPMSG1169_str:
 	.pascii "VREG"
 
 	; BPMSG1170
+	.section .text.BPMSG1170, code
+	.global _BPMSG1170_str
+_BPMSG1170_str:
 	.pascii "ADC and supply"
 
 	; BPMSG1171
+	.section .text.BPMSG1171, code
+	.global _BPMSG1171_str
+_BPMSG1171_str:
 	.pascii "5V"
 
 	; BPMSG1172
+	.section .text.BPMSG1172, code
+	.global _BPMSG1172_str
+_BPMSG1172_str:
 	.pascii "VPU"
 
 	; BPMSG1173
+	.section .text.BPMSG1173, code
+	.global _BPMSG1173_str
+_BPMSG1173_str:
 	.pascii "3.3V"
 
 	; BPMSG1174
+	.section .text.BPMSG1174, code
+	.global _BPMSG1174_str
+_BPMSG1174_str:
 	.pascii "ADC"
 
 	; BPMSG1175
+	.section .text.BPMSG1175, code
+	.global _BPMSG1175_str
+_BPMSG1175_str:
 	.pascii "Bus high"
 
 	; BPMSG1176
+	.section .text.BPMSG1176, code
+	.global _BPMSG1176_str
+_BPMSG1176_str:
 	.pascii "Bus Hi-Z 0"
 
 	; BPMSG1177
+	.section .text.BPMSG1177, code
+	.global _BPMSG1177_str
+_BPMSG1177_str:
 	.pascii "Bus Hi-Z 1"
 
 	; BPMSG1178
+	.section .text.BPMSG1178, code
+	.global _BPMSG1178_str
+_BPMSG1178_str:
 	.pascii "MODE and VREG LEDs should be on!"
 
 	; BPMSG1179
+	.section .text.BPMSG1179, code
+	.global _BPMSG1179_str
+_BPMSG1179_str:
 	.pascii "Found "
 
 	; BPMSG1180
+	.section .text.BPMSG1180, code
+	.global _BPMSG1180_str
+_BPMSG1180_str:
 	.pascii " errors."
 
 	; BPMSG1181
+	.section .text.BPMSG1181, code
+	.global _BPMSG1181_str
+_BPMSG1181_str:
 	.pascii "MOSI"
 
 	; BPMSG1182
+	.section .text.BPMSG1182, code
+	.global _BPMSG1182_str
+_BPMSG1182_str:
 	.pascii "CLK"
 
 	; BPMSG1183
+	.section .text.BPMSG1183, code
+	.global _BPMSG1183_str
+_BPMSG1183_str:
 	.pascii "MISO"
 
 	; BPMSG1184
+	.section .text.BPMSG1184, code
+	.global _BPMSG1184_str
+_BPMSG1184_str:
 	.pascii "CS"
 
 	; BPMSG1185
+	.section .text.BPMSG1185, code
+	.global _BPMSG1185_str
+_BPMSG1185_str:
 	.pascii " OK"
 
 	; BPMSG1186
+	.section .text.BPMSG1186, code
+	.global _BPMSG1186_str
+_BPMSG1186_str:
 	.pascii " FAIL"
 
 	; BPMSG1187
+	.section .text.BPMSG1187, code
+	.global _BPMSG1187_str
+_BPMSG1187_str:
 	.pascii "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
 
 	; BPMSG1188
+	.section .text.BPMSG1188, code
+	.global _BPMSG1188_str
+_BPMSG1188_str:
 	.pascii "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
 
 	; BPMSG1189
+	.section .text.BPMSG1189, code
+	.global _BPMSG1189_str
+_BPMSG1189_str:
 	.pascii "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
 
 	; BPMSG1190
+	.section .text.BPMSG1190, code
+	.global _BPMSG1190_str
+_BPMSG1190_str:
 	.pascii "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
 
 	; BPMSG1191
+	.section .text.BPMSG1191, code
+	.global _BPMSG1191_str
+_BPMSG1191_str:
 	.pascii "SPI (spd ckp ske smp csl hiz)=( "
 
 	; BPMSG1192
+	.section .text.BPMSG1192, code
+	.global _BPMSG1192_str
+_BPMSG1192_str:
 	.pascii " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic"
 
 	; BPMSG1194
+	.section .text.BPMSG1194, code
+	.global _BPMSG1194_str
+_BPMSG1194_str:
 	.pascii "-p "
 
 	; BPMSG1195
+	.section .text.BPMSG1195, code
+	.global _BPMSG1195_str
+_BPMSG1195_str:
 	.pascii "-f "
 
 	; BPMSG1196
+	.section .text.BPMSG1196, code
+	.global _BPMSG1196_str
+_BPMSG1196_str:
 	.pascii "*Bytes dropped*"
 
 	; BPMSG1197
+	.section .text.BPMSG1197, code
+	.global _BPMSG1197_str
+_BPMSG1197_str:
 	.pascii "FAILED, NO DATA"
 
 	; BPMSG1199
+	.section .text.BPMSG1199, code
+	.global _BPMSG1199_str
+_BPMSG1199_str:
 	.pascii "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
 
 	; BPMSG1200
+	.section .text.BPMSG1200, code
+	.global _BPMSG1200_str
+_BPMSG1200_str:
 	.pascii "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
 
 	; BPMSG1201
+	.section .text.BPMSG1201, code
+	.global _BPMSG1201_str
+_BPMSG1201_str:
 	.pascii "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
 
 	; BPMSG1202
+	.section .text.BPMSG1202, code
+	.global _BPMSG1202_str
+_BPMSG1202_str:
 	.pascii "UART (spd brg dbp sb rxp hiz)=( "
 
 	; BPMSG1203
+	.section .text.BPMSG1203, code
+	.global _BPMSG1203_str
+_BPMSG1203_str:
 	.pascii " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection"
 
 	; BPMSG1204
+	.section .text.BPMSG1204, code
+	.global _BPMSG1204_str
+_BPMSG1204_str:
 	.pascii "UART bridge"
 
 	; BPMSG1206
+	.section .text.BPMSG1206, code
+	.global _BPMSG1206_str
+_BPMSG1206_str:
 	.pascii "Raw UART input"
 
 	; BPMSG1207
+	.section .text.BPMSG1207, code
+	.global _BPMSG1207_str
+_BPMSG1207_str:
 	.pascii "UART LIVE DISPLAY, } TO STOP"
 
 	; BPMSG1208
+	.section .text.BPMSG1208, code
+	.global _BPMSG1208_str
+_BPMSG1208_str:
 	.pascii "LIVE DISPLAY STOPPED"
 
 	; BPMSG1209
+	.section .text.BPMSG1209, code
+	.global _BPMSG1209_str
+_BPMSG1209_str:
 	.pascii "WARNING: pins not open drain (HiZ)"
 
 	; BPMSG1210
+	.section .text.BPMSG1210, code
+	.global _BPMSG1210_str
+_BPMSG1210_str:
 	.pascii " REVID:"
 
 	; BPMSG1211
+	.section .text.BPMSG1211, code
+	.global _BPMSG1211_str
+_BPMSG1211_str:
 	.pascii "\r\nInvalid choice, try again"
 
 	; BPMSG1212
+	.section .text.BPMSG1212, code
+	.global _BPMSG1212_str
+_BPMSG1212_str:
 	.pascii "ms"
 
 	; BPMSG1213
+	.section .text.BPMSG1213, code
+	.global _BPMSG1213_str
+_BPMSG1213_str:
 	.pascii "RS LOW, COMMAND MODE"
 
 	; BPMSG1214
+	.section .text.BPMSG1214, code
+	.global _BPMSG1214_str
+_BPMSG1214_str:
 	.pascii "RS HIGH, DATA MODE"
 
 	; BPMSG1216
+	.section .text.BPMSG1216, code
+	.global _BPMSG1216_str
+_BPMSG1216_str:
 	.pascii "This mode requires an adapter"
 
 	; BPMSG1219
+	.section .text.BPMSG1219, code
+	.global _BPMSG1219_str
+_BPMSG1219_str:
 	.pascii " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
 
 	; BPMSG1220
+	.section .text.BPMSG1220, code
+	.global _BPMSG1220_str
+_BPMSG1220_str:
 	.pascii "Display lines:\r\n 1. 1 \r\n 2. Multiple"
 
 	; BPMSG1221
+	.section .text.BPMSG1221, code
+	.global _BPMSG1221_str
+_BPMSG1221_str:
 	.pascii "INIT"
 
 	; BPMSG1222
+	.section .text.BPMSG1222, code
+	.global _BPMSG1222_str
+_BPMSG1222_str:
 	.pascii "CLEAR"
 
 	; BPMSG1223
+	.section .text.BPMSG1223, code
+	.global _BPMSG1223_str
+_BPMSG1223_str:
 	.pascii "CURSOR SET"
 
 	; BPMSG1226
+	.section .text.BPMSG1226, code
+	.global _BPMSG1226_str
+_BPMSG1226_str:
 	.pascii "Pinstates:"
 
 	; BPMSG1227
+	.section .text.BPMSG1227, code
+	.global _BPMSG1227_str
+_BPMSG1227_str:
 	.pascii "GND\t3.3V\t5.0V\tADC\tVPU\tAUX\t"
 
 	; BPMSG1228
+	.section .text.BPMSG1228, code
+	.global _BPMSG1228_str
+_BPMSG1228_str:
 	.pascii "P\tP\tP\tI\tI\t"
 
 	; BPMSG1229
+	.section .text.BPMSG1229, code
+	.global _BPMSG1229_str
+_BPMSG1229_str:
 	.pascii "-\tOWD\t-\t-"
 
 	; BPMSG1232
+	.section .text.BPMSG1232, code
+	.global _BPMSG1232_str
+_BPMSG1232_str:
 	.pascii "PGC\tPGD\t-\t-"
 
 	; BPMSG1233
+	.section .text.BPMSG1233, code
+	.global _BPMSG1233_str
+_BPMSG1233_str:
 	.pascii "1.(BR)\t2.(RD)\t3.(OR)\t4.(YW)\t5.(GN)\t6.(BL)\t7.(PU)\t8.(GR)\t9.(WT)\t0.(Blk)"
 
 	; BPMSG1234
+	.section .text.BPMSG1234, code
+	.global _BPMSG1234_str
+_BPMSG1234_str:
 	.pascii "GND\t"
 
 	; BPMSG1237
+	.section .text.BPMSG1237, code
+	.global _BPMSG1237_str
+_BPMSG1237_str:
 	.pascii " TIMEOUT"
 
 	; BPMSG1238
+	.section .text.BPMSG1238, code
+	.global _BPMSG1238_str
+_BPMSG1238_str:
 	.pascii " 0. Macro menu\r\n 1. Live input monitor"
 
 	; BPMSG1239
+	.section .text.BPMSG1239, code
+	.global _BPMSG1239_str
+_BPMSG1239_str:
 	.pascii "Input monitor, any key exits"
 
 	; BPMSG1240
+	.section .text.BPMSG1240, code
+	.global _BPMSG1240_str
+_BPMSG1240_str:
 	.pascii " *startbit error"
 
 	; BPMSG1241
+	.section .text.BPMSG1241, code
+	.global _BPMSG1241_str
+_BPMSG1241_str:
 	.pascii " *parity error"
 
 	; BPMSG1242
+	.section .text.BPMSG1242, code
+	.global _BPMSG1242_str
+_BPMSG1242_str:
 	.pascii " *stopbit error"
 
 	; BPMSG1243
+	.section .text.BPMSG1243, code
+	.global _BPMSG1243_str
+_BPMSG1243_str:
 	.pascii " NONE"
 
 	; BPMSG1244
+	.section .text.BPMSG1244, code
+	.global _BPMSG1244_str
+_BPMSG1244_str:
 	.pascii " UNKNOWN ERROR"
 
 	; BPMSG1245
+	.section .text.BPMSG1245, code
+	.global _BPMSG1245_str
+_BPMSG1245_str:
 	.pascii " autorange "
 
 	; BPMSG1248
+	.section .text.BPMSG1248, code
+	.global _BPMSG1248_str
+_BPMSG1248_str:
 	.pascii "Raw value for BRG (MIDI=127)"
 
 	; BPMSG1250
+	.section .text.BPMSG1250, code
+	.global _BPMSG1250_str
+_BPMSG1250_str:
 	.pascii "Any key to exit"
 
 	; BPMSG1251
+	.section .text.BPMSG1251, code
+	.global _BPMSG1251_str
+_BPMSG1251_str:
 	.pascii "Space to continue"
 
 	; BPMSG1252
+	.section .text.BPMSG1252, code
+	.global _BPMSG1252_str
+_BPMSG1252_str:
 	.pascii "Number of bits read/write: "
 
 	; BPMSG1254
+	.section .text.BPMSG1254, code
+	.global _BPMSG1254_str
+_BPMSG1254_str:
 	.pascii "Position in degrees"
 
 	; BPMSG1255
+	.section .text.BPMSG1255, code
+	.global _BPMSG1255_str
+_BPMSG1255_str:
 	.pascii "Servo active"
 
 	; BPMSG1280
+	.section .text.BPMSG1280, code
+	.global _BPMSG1280_str
+_BPMSG1280_str:
 	.pascii "Waiting activity..."
 
 	; BPMSG1281
+	.section .text.BPMSG1281, code
+	.global _BPMSG1281_str
+_BPMSG1281_str:
 	.pascii "** Early Exit!"
 
 	; BPMSG1282
+	.section .text.BPMSG1282, code
+	.global _BPMSG1282_str
+_BPMSG1282_str:
 	.pascii "**Baud>16m: BP Cannot measure > 16000000, Done."
 
 	; BPMSG1283
+	.section .text.BPMSG1283, code
+	.global _BPMSG1283_str
+_BPMSG1283_str:
 	.pascii "\n\rCalculated: \t"
 
 	; BPMSG1284
+	.section .text.BPMSG1284, code
+	.global _BPMSG1284_str
+_BPMSG1284_str:
 	.pascii "\n\rEstimated:  \t"
 
 	; BPMSG1285
+	.section .text.BPMSG1285, code
+	.global _BPMSG1285_str
+_BPMSG1285_str:
 	.pascii " bps"
 
 	; HLP1000
+	.section .text.HLP1000, code
+	.global _HLP1000_str
+_HLP1000_str:
 	.pascii " General\t\t\t\t\tProtocol interaction"
 
 	; HLP1001
+	.section .text.HLP1001, code
+	.global _HLP1001_str
+_HLP1001_str:
 	.pascii " ---------------------------------------------------------------------------"
 
 	; HLP1002
+	.section .text.HLP1002, code
+	.global _HLP1002_str
+_HLP1002_str:
 	.pascii " ?\tThis help\t\t\t(0)\tList current macros"
 
 	; HLP1003
+	.section .text.HLP1003, code
+	.global _HLP1003_str
+_HLP1003_str:
 	.pascii " =X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
 
 	; HLP1004
+	.section .text.HLP1004, code
+	.global _HLP1004_str
+_HLP1004_str:
 	.pascii " ~\tSelftest\t\t\t[\tStart"
 
 	; HLP1005
+	.section .text.HLP1005, code
+	.global _HLP1005_str
+_HLP1005_str:
 	.pascii " #\tReset the BP   \t\t\t]\tStop"
 
 	; HLP1006
+	.section .text.HLP1006, code
+	.global _HLP1006_str
+_HLP1006_str:
 	.pascii " $\tJump to bootloader\t\t{\tStart with read"
 
 	; HLP1007
+	.section .text.HLP1007, code
+	.global _HLP1007_str
+_HLP1007_str:
 	.pascii " &/%\tDelay 1 us/ms\t\t\t}\tStop"
 
 	; HLP1008
+	.section .text.HLP1008, code
+	.global _HLP1008_str
+_HLP1008_str:
 	.pascii " a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
 
 	; HLP1009
+	.section .text.HLP1009, code
+	.global _HLP1009_str
+_HLP1009_str:
 	.pascii " b\tSet baudrate\t\t\t123"
 
 	; HLP1010
+	.section .text.HLP1010, code
+	.global _HLP1010_str
+_HLP1010_str:
 	.pascii " c/C\tAUX assignment (aux/CS)\t\t0x123"
 
 	; HLP1011
+	.section .text.HLP1011, code
+	.global _HLP1011_str
+_HLP1011_str:
 	.pascii " d/D\tMeasure ADC (once/CONT.)\t0b110\tSend value"
 
 	; HLP1012
+	.section .text.HLP1012, code
+	.global _HLP1012_str
+_HLP1012_str:
 	.pascii " f\tMeasure frequency\t\tr\tRead"
 
 	; HLP1013
+	.section .text.HLP1013, code
+	.global _HLP1013_str
+_HLP1013_str:
 	.pascii " g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
 
 	; HLP1014
+	.section .text.HLP1014, code
+	.global _HLP1014_str
+_HLP1014_str:
 	.pascii " h\tCommandhistory\t\t\t\\\tCLK lo"
 
 	; HLP1015
+	.section .text.HLP1015, code
+	.global _HLP1015_str
+_HLP1015_str:
 	.pascii " i\tVersioninfo/statusinfo\t\t^\tCLK tick"
 
 	; HLP1016
+	.section .text.HLP1016, code
+	.global _HLP1016_str
+_HLP1016_str:
 	.pascii " l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
 
 	; HLP1017
+	.section .text.HLP1017, code
+	.global _HLP1017_str
+_HLP1017_str:
 	.pascii " m\tChange mode\t\t\t_\tDAT lo"
 
 	; HLP1018
+	.section .text.HLP1018, code
+	.global _HLP1018_str
+_HLP1018_str:
 	.pascii " o\tSet output type\t\t\t.\tDAT read"
 
 	; HLP1019
+	.section .text.HLP1019, code
+	.global _HLP1019_str
+_HLP1019_str:
 	.pascii " p/P\tPullup resistors (off/ON)\t!\tBit read"
 
 	; HLP1020
+	.section .text.HLP1020, code
+	.global _HLP1020_str
+_HLP1020_str:
 	.pascii " s\tScript engine\t\t\t:\tRepeat e.g. r:10"
 
 	; HLP1021
+	.section .text.HLP1021, code
+	.global _HLP1021_str
+_HLP1021_str:
 	.pascii " v\tShow volts/states\t\t.\tBits to read/write e.g. 0x55.2"
 
 	; HLP1022
+	.section .text.HLP1022, code
+	.global _HLP1022_str
+_HLP1022_str:
 	.pascii " w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
 
 	; MSG_1WIRE_MODE_IDENTIFIER
+	.section .text.MSG_1WIRE_MODE_IDENTIFIER, code
+	.global _MSG_1WIRE_MODE_IDENTIFIER_str
+_MSG_1WIRE_MODE_IDENTIFIER_str:
 	.pascii "1W01"
 
 	; MSG_1WIRE_SPEED_PROMPT
+	.section .text.MSG_1WIRE_SPEED_PROMPT, code
+	.global _MSG_1WIRE_SPEED_PROMPT_str
+_MSG_1WIRE_SPEED_PROMPT_str:
 	.pascii "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
 
 	; MSG_ACK
+	.section .text.MSG_ACK, code
+	.global _MSG_ACK_str
+_MSG_ACK_str:
 	.pascii "ACK"
 
 	; MSG_BASE_CONVERTER_EQUAL_SIGN
+	.section .text.MSG_BASE_CONVERTER_EQUAL_SIGN, code
+	.global _MSG_BASE_CONVERTER_EQUAL_SIGN_str
+_MSG_BASE_CONVERTER_EQUAL_SIGN_str:
 	.pascii " = "
 
 	; MSG_BBIO_MODE_IDENTIFIER
+	.section .text.MSG_BBIO_MODE_IDENTIFIER, code
+	.global _MSG_BBIO_MODE_IDENTIFIER_str
+_MSG_BBIO_MODE_IDENTIFIER_str:
 	.pascii "BBIO1"
 
 	; MSG_BINARY_NUMBER_PREFIX
+	.section .text.MSG_BINARY_NUMBER_PREFIX, code
+	.global _MSG_BINARY_NUMBER_PREFIX_str
+_MSG_BINARY_NUMBER_PREFIX_str:
 	.pascii "0b"
 
 	; MSG_CHIP_IDENTIFIER_CLONE
+	.section .text.MSG_CHIP_IDENTIFIER_CLONE, code
+	.global _MSG_CHIP_IDENTIFIER_CLONE_str
+_MSG_CHIP_IDENTIFIER_CLONE_str:
 	.pascii " clone w/different PIC"
 
 	; MSG_CHIP_REVISION_A3
+	.section .text.MSG_CHIP_REVISION_A3, code
+	.global _MSG_CHIP_REVISION_A3_str
+_MSG_CHIP_REVISION_A3_str:
 	.pascii "A3"
 
 	; MSG_CHIP_REVISION_B4
+	.section .text.MSG_CHIP_REVISION_B4, code
+	.global _MSG_CHIP_REVISION_B4_str
+_MSG_CHIP_REVISION_B4_str:
 	.pascii "B4"
 
 	; MSG_CHIP_REVISION_B5
+	.section .text.MSG_CHIP_REVISION_B5, code
+	.global _MSG_CHIP_REVISION_B5_str
+_MSG_CHIP_REVISION_B5_str:
 	.pascii "B5"
 
 	; MSG_CHIP_REVISION_B8
+	.section .text.MSG_CHIP_REVISION_B8, code
+	.global _MSG_CHIP_REVISION_B8_str
+_MSG_CHIP_REVISION_B8_str:
 	.pascii "B8"
 
 	; MSG_CHIP_REVISION_ID_BEGIN
+	.section .text.MSG_CHIP_REVISION_ID_BEGIN, code
+	.global _MSG_CHIP_REVISION_ID_BEGIN_str
+_MSG_CHIP_REVISION_ID_BEGIN_str:
 	.pascii " (24FJ64GA00 "
 
 	; MSG_CHIP_REVISION_ID_END_2
+	.section .text.MSG_CHIP_REVISION_ID_END_2, code
+	.global _MSG_CHIP_REVISION_ID_END_2_str
+_MSG_CHIP_REVISION_ID_END_2_str:
 	.pascii "2 "
 
 	; MSG_CHIP_REVISION_ID_END_4
+	.section .text.MSG_CHIP_REVISION_ID_END_4, code
+	.global _MSG_CHIP_REVISION_ID_END_4_str
+_MSG_CHIP_REVISION_ID_END_4_str:
 	.pascii "4 "
 
 	; MSG_CHIP_REVISION_UNKNOWN
+	.section .text.MSG_CHIP_REVISION_UNKNOWN, code
+	.global _MSG_CHIP_REVISION_UNKNOWN_str
+_MSG_CHIP_REVISION_UNKNOWN_str:
 	.pascii "UNK"
 
 	; MSG_CLUTCH_DISENGAGED
+	.section .text.MSG_CLUTCH_DISENGAGED, code
+	.global _MSG_CLUTCH_DISENGAGED_str
+_MSG_CLUTCH_DISENGAGED_str:
 	.pascii "Clutch disengaged!!!"
 
 	; MSG_CLUTCH_ENGAGED
+	.section .text.MSG_CLUTCH_ENGAGED, code
+	.global _MSG_CLUTCH_ENGAGED_str
+_MSG_CLUTCH_ENGAGED_str:
 	.pascii "Clutch engaged!!!"
 
 	; MSG_FINISH_SETUP_PROMPT
+	.section .text.MSG_FINISH_SETUP_PROMPT, code
+	.global _MSG_FINISH_SETUP_PROMPT_str
+_MSG_FINISH_SETUP_PROMPT_str:
 	.pascii "To finish setup, start up the power supplies with command 'W'"
 
 	; MSG_HEXADECIMAL_NUMBER_PREFIX
+	.section .text.MSG_HEXADECIMAL_NUMBER_PREFIX, code
+	.global _MSG_HEXADECIMAL_NUMBER_PREFIX_str
+_MSG_HEXADECIMAL_NUMBER_PREFIX_str:
 	.pascii "0x"
 
 	; MSG_I2C_MODE_IDENTIFIER
+	.section .text.MSG_I2C_MODE_IDENTIFIER, code
+	.global _MSG_I2C_MODE_IDENTIFIER_str
+_MSG_I2C_MODE_IDENTIFIER_str:
 	.pascii "I2C1"
 
 	; MSG_I2C_PINS_STATE
+	.section .text.MSG_I2C_PINS_STATE, code
+	.global _MSG_I2C_PINS_STATE_str
+_MSG_I2C_PINS_STATE_str:
 	.pascii "SCL\tSDA\t-\t-"
 
 	; MSG_I2C_READ_ADDRESS_END
+	.section .text.MSG_I2C_READ_ADDRESS_END, code
+	.global _MSG_I2C_READ_ADDRESS_END_str
+_MSG_I2C_READ_ADDRESS_END_str:
 	.pascii " R) "
 
 	; MSG_I2C_START_BIT
+	.section .text.MSG_I2C_START_BIT, code
+	.global _MSG_I2C_START_BIT_str
+_MSG_I2C_START_BIT_str:
 	.pascii "I2C START BIT"
 
 	; MSG_I2C_STOP_BIT
+	.section .text.MSG_I2C_STOP_BIT, code
+	.global _MSG_I2C_STOP_BIT_str
+_MSG_I2C_STOP_BIT_str:
 	.pascii "I2C STOP BIT"
 
 	; MSG_I2C_WRITE_ADDRESS_END
+	.section .text.MSG_I2C_WRITE_ADDRESS_END, code
+	.global _MSG_I2C_WRITE_ADDRESS_END_str
+_MSG_I2C_WRITE_ADDRESS_END_str:
 	.pascii " W) "
 
 	; MSG_MODE_HEADER_END
+	.section .text.MSG_MODE_HEADER_END, code
+	.global _MSG_MODE_HEADER_END_str
+_MSG_MODE_HEADER_END_str:
 	.pascii " )"
 
 	; MSG_NACK
+	.section .text.MSG_NACK, code
+	.global _MSG_NACK_str
+_MSG_NACK_str:
 	.pascii "NACK"
 
 	; MSG_NO_VOLTAGE_ON_PULLUP_PIN
+	.section .text.MSG_NO_VOLTAGE_ON_PULLUP_PIN, code
+	.global _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str
+_MSG_NO_VOLTAGE_ON_PULLUP_PIN_str:
 	.pascii "Warning: no voltage on Vpullup pin"
 
 	; MSG_OPENOCD_MODE_IDENTIFIER
+	.section .text.MSG_OPENOCD_MODE_IDENTIFIER, code
+	.global _MSG_OPENOCD_MODE_IDENTIFIER_str
+_MSG_OPENOCD_MODE_IDENTIFIER_str:
 	.pascii "OCD1"
 
 	; MSG_PIC_MODE_IDENTIFIER
+	.section .text.MSG_PIC_MODE_IDENTIFIER, code
+	.global _MSG_PIC_MODE_IDENTIFIER_str
+_MSG_PIC_MODE_IDENTIFIER_str:
 	.pascii "PIC1"
 
 	; MSG_PIC_UNKNOWN_MODE
+	.section .text.MSG_PIC_UNKNOWN_MODE, code
+	.global _MSG_PIC_UNKNOWN_MODE_str
+_MSG_PIC_UNKNOWN_MODE_str:
 	.pascii "unknown mode"
 
 	; MSG_PIN_OUTPUT_TYPE_PROMPT
+	.section .text.MSG_PIN_OUTPUT_TYPE_PROMPT, code
+	.global _MSG_PIN_OUTPUT_TYPE_PROMPT_str
+_MSG_PIN_OUTPUT_TYPE_PROMPT_str:
 	.pascii "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
 
 	; MSG_PWM_FREQUENCY_TOO_LOW
+	.section .text.MSG_PWM_FREQUENCY_TOO_LOW, code
+	.global _MSG_PWM_FREQUENCY_TOO_LOW_str
+_MSG_PWM_FREQUENCY_TOO_LOW_str:
 	.pascii "Frequencies < 1Hz are not supported."
 
 	; MSG_PWM_HZ_MARKER
+	.section .text.MSG_PWM_HZ_MARKER, code
+	.global _MSG_PWM_HZ_MARKER_str
+_MSG_PWM_HZ_MARKER_str:
 	.pascii " Hz"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str
+_MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str:
 	.pascii "Data units: "
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str
+_MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str:
 	.pascii "no indication"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str
+_MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str:
 	.pascii "Data unit length (bits): "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str:
 	.pascii "2 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str:
 	.pascii "3 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str:
 	.pascii "Protocol: "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str:
 	.pascii "serial"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str:
 	.pascii "unknown"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str:
 	.pascii "Read type: "
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_TO_END
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_TO_END, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str:
 	.pascii "to end"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str:
 	.pascii "variable length"
 
 	; MSG_RAW2WIRE_ATR_REPLY_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_REPLY_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_REPLY_HEADER_str
+_MSG_RAW2WIRE_ATR_REPLY_HEADER_str:
 	.pascii "ISO 7816-3 reply (uses current LSB setting): "
 
 	; MSG_RAW2WIRE_ATR_RFU
+	.section .text.MSG_RAW2WIRE_ATR_RFU, code
+	.global _MSG_RAW2WIRE_ATR_RFU_str
+_MSG_RAW2WIRE_ATR_RFU_str:
 	.pascii "RFU"
 
 	; MSG_RAW2WIRE_ATR_TRIGGER_INFO
+	.section .text.MSG_RAW2WIRE_ATR_TRIGGER_INFO, code
+	.global _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str
+_MSG_RAW2WIRE_ATR_TRIGGER_INFO_str:
 	.pascii "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
 
 	; MSG_RAW2WIRE_I2C_START
+	.section .text.MSG_RAW2WIRE_I2C_START, code
+	.global _MSG_RAW2WIRE_I2C_START_str
+_MSG_RAW2WIRE_I2C_START_str:
 	.pascii "(\\-/_\\-)"
 
 	; MSG_RAW2WIRE_I2C_STOP
+	.section .text.MSG_RAW2WIRE_I2C_STOP, code
+	.global _MSG_RAW2WIRE_I2C_STOP_str
+_MSG_RAW2WIRE_I2C_STOP_str:
 	.pascii "(\\_/-)"
 
 	; MSG_RAW2WIRE_MACRO_MENU
+	.section .text.MSG_RAW2WIRE_MACRO_MENU, code
+	.global _MSG_RAW2WIRE_MACRO_MENU_str
+_MSG_RAW2WIRE_MACRO_MENU_str:
 	.pascii " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
 
 	; MSG_RAW2WIRE_MODE_HEADER
+	.section .text.MSG_RAW2WIRE_MODE_HEADER, code
+	.global _MSG_RAW2WIRE_MODE_HEADER_str
+_MSG_RAW2WIRE_MODE_HEADER_str:
 	.pascii "R2W (spd hiz)=( "
 
 	; MSG_RAW3WIRE_MODE_HEADER
+	.section .text.MSG_RAW3WIRE_MODE_HEADER, code
+	.global _MSG_RAW3WIRE_MODE_HEADER_str
+_MSG_RAW3WIRE_MODE_HEADER_str:
 	.pascii "R3W (spd csl hiz)=( "
 
 	; MSG_RAW_BRG_VALUE_INPUT
+	.section .text.MSG_RAW_BRG_VALUE_INPUT, code
+	.global _MSG_RAW_BRG_VALUE_INPUT_str
+_MSG_RAW_BRG_VALUE_INPUT_str:
 	.pascii "Enter raw value for BRG"
 
 	; MSG_RAW_MODE_IDENTIFIER
+	.section .text.MSG_RAW_MODE_IDENTIFIER, code
+	.global _MSG_RAW_MODE_IDENTIFIER_str
+_MSG_RAW_MODE_IDENTIFIER_str:
 	.pascii "RAW1"
 
 	; MSG_SOFTWARE_MODE_SPEED_PROMPT
+	.section .text.MSG_SOFTWARE_MODE_SPEED_PROMPT, code
+	.global _MSG_SOFTWARE_MODE_SPEED_PROMPT_str
+_MSG_SOFTWARE_MODE_SPEED_PROMPT_str:
 	.pascii "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
 
 	; MSG_SPI_COULD_NOT_KEEP_UP
+	.section .text.MSG_SPI_COULD_NOT_KEEP_UP, code
+	.global _MSG_SPI_COULD_NOT_KEEP_UP_str
+_MSG_SPI_COULD_NOT_KEEP_UP_str:
 	.pascii "Couldn't keep up"
 
 	; MSG_SPI_CS_DISABLED
+	.section .text.MSG_SPI_CS_DISABLED, code
+	.global _MSG_SPI_CS_DISABLED_str
+_MSG_SPI_CS_DISABLED_str:
 	.pascii "CS DISABLED"
 
 	; MSG_SPI_CS_ENABLED
+	.section .text.MSG_SPI_CS_ENABLED, code
+	.global _MSG_SPI_CS_ENABLED_str
+_MSG_SPI_CS_ENABLED_str:
 	.pascii "CS ENABLED"
 
 	; MSG_SPI_CS_MODE_PROMPT
+	.section .text.MSG_SPI_CS_MODE_PROMPT, code
+	.global _MSG_SPI_CS_MODE_PROMPT_str
+_MSG_SPI_CS_MODE_PROMPT_str:
 	.pascii "CS:\r\n 1. CS\r\n 2. /CS *default"
 
 	; MSG_SPI_MODE_IDENTIFIER
+	.section .text.MSG_SPI_MODE_IDENTIFIER, code
+	.global _MSG_SPI_MODE_IDENTIFIER_str
+_MSG_SPI_MODE_IDENTIFIER_str:
 	.pascii "SPI1"
 
 	; MSG_SPI_PINS_STATE
+	.section .text.MSG_SPI_PINS_STATE, code
+	.global _MSG_SPI_PINS_STATE_str
+_MSG_SPI_PINS_STATE_str:
 	.pascii "CLK\tMOSI\tCS\tMISO"
 
 	; MSG_UART_MODE_IDENTIFIER
+	.section .text.MSG_UART_MODE_IDENTIFIER, code
+	.global _MSG_UART_MODE_IDENTIFIER_str
+_MSG_UART_MODE_IDENTIFIER_str:
 	.pascii "ART1"
 
 	; MSG_UART_PINS_STATE
+	.section .text.MSG_UART_PINS_STATE, code
+	.global _MSG_UART_PINS_STATE_str
+_MSG_UART_PINS_STATE_str:
 	.pascii "-\tTxD\t-\tRxD"
 
 	; MSG_UART_POSSIBLE_OVERFLOW
+	.section .text.MSG_UART_POSSIBLE_OVERFLOW, code
+	.global _MSG_UART_POSSIBLE_OVERFLOW_str
+_MSG_UART_POSSIBLE_OVERFLOW_str:
 	.pascii "WARNING: Possible buffer overflow"
 
 	; MSG_UART_RESET_TO_EXIT
+	.section .text.MSG_UART_RESET_TO_EXIT, code
+	.global _MSG_UART_RESET_TO_EXIT_str
+_MSG_UART_RESET_TO_EXIT_str:
 	.pascii "Reset to exit"
 
 	; MSG_UNKNOWN_MACRO_ERROR
+	.section .text.MSG_UNKNOWN_MACRO_ERROR, code
+	.global _MSG_UNKNOWN_MACRO_ERROR_str
+_MSG_UNKNOWN_MACRO_ERROR_str:
 	.pascii "Unknown macro, try ? or (0) for help"
 
 	; MSG_VREG_TOO_LOW
+	.section .text.MSG_VREG_TOO_LOW, code
+	.global _MSG_VREG_TOO_LOW_str
+_MSG_VREG_TOO_LOW_str:
 	.pascii "VREG too low, is there a short?"
 

--- a/Firmware/messages_v4.h
+++ b/Firmware/messages_v4.h
@@ -1,304 +1,603 @@
 #ifndef BP_MESSAGES_V4_H
 #define BP_MESSAGES_V4_H
 
-#define BPMSG1001 bp_message_write_line(0, 36)
-#define BPMSG1004 bp_message_write_line(36, 41)
-#define BPMSG1005 bp_message_write_buffer(77, 14)
-#define BPMSG1006 bp_message_write_line(91, 13)
-#define BPMSG1007 bp_message_write_line(104, 23)
-#define BPMSG1008 bp_message_write_buffer(127, 6)
-#define BPMSG1009 bp_message_write_line(133, 211)
-#define BPMSG1010 bp_message_write_line(344, 19)
-#define BPMSG1011 bp_message_write_line(363, 13)
-#define BPMSG1012 bp_message_write_line(376, 43)
-#define BPMSG1013 bp_message_write_buffer(419, 17)
-#define BPMSG1014 bp_message_write_line(436, 16)
-#define BPMSG1015 bp_message_write_line(452, 15)
-#define BPMSG1017 bp_message_write_buffer(467, 10)
-#define BPMSG1019 bp_message_write_buffer(477, 9)
-#define BPMSG1020 bp_message_write_buffer(486, 21)
-#define BPMSG1021 bp_message_write_buffer(507, 20)
-#define BPMSG1022 bp_message_write_buffer(527, 27)
-#define BPMSG1023 bp_message_write_buffer(554, 26)
-#define BPMSG1024 bp_message_write_buffer(580, 21)
-#define BPMSG1025 bp_message_write_buffer(601, 24)
-#define BPMSG1026 bp_message_write_buffer(625, 16)
-#define BPMSG1027 bp_message_write_buffer(641, 14)
-#define BPMSG1028 bp_message_write_line(655, 12)
-#define BPMSG1029 bp_message_write_line(667, 17)
-#define BPMSG1030 bp_message_write_buffer(684, 17)
-#define BPMSG1033 bp_message_write_buffer(701, 16)
-#define BPMSG1034 bp_message_write_line(717, 10)
-#define BPMSG1037 bp_message_write_line(727, 31)
-#define BPMSG1038 bp_message_write_buffer(758, 15)
-#define BPMSG1039 bp_message_write_buffer(773, 14)
-#define BPMSG1040 bp_message_write_line(787, 8)
-#define BPMSG1041 bp_message_write_line(795, 7)
-#define BPMSG1042 bp_message_write_line(802, 14)
-#define BPMSG1044 bp_message_write_buffer(816, 15)
-#define BPMSG1045 bp_message_write_buffer(831, 1)
-#define BPMSG1047 bp_message_write_buffer(832, 6)
-#define BPMSG1048 bp_message_write_buffer(838, 8)
-#define BPMSG1049 bp_message_write_buffer(846, 11)
-#define BPMSG1050 bp_message_write_line(857, 7)
-#define BPMSG1051 bp_message_write_line(864, 9)
-#define BPMSG1052 bp_message_write_line(873, 12)
-#define BPMSG1053 bp_message_write_line(885, 9)
-#define BPMSG1054 bp_message_write_buffer(894, 7)
-#define BPMSG1055 bp_message_write_line(901, 4)
-#define BPMSG1056 bp_message_write_buffer(905, 15)
-#define BPMSG1057 bp_message_write_line(920, 12)
-#define BPMSG1058 bp_message_write_buffer(932, 18)
-#define BPMSG1059 bp_message_write_line(950, 33)
-#define BPMSG1064 bp_message_write_line(983, 37)
-#define BPMSG1067 bp_message_write_buffer(1020, 44)
-#define BPMSG1068 bp_message_write_buffer(1064, 16)
-#define BPMSG1069 bp_message_write_buffer(1080, 123)
-#define BPMSG1070 bp_message_write_line(1203, 46)
-#define BPMSG1071 bp_message_write_line(1249, 7)
-#define BPMSG1072 bp_message_write_line(1256, 34)
-#define BPMSG1073 bp_message_write_line(1290, 6)
-#define BPMSG1074 bp_message_write_buffer(1296, 14)
-#define BPMSG1075 bp_message_write_buffer(1310, 3)
-#define BPMSG1076 bp_message_write_line(1313, 3)
-#define BPMSG1077 bp_message_write_line(1316, 7)
-#define BPMSG1078 bp_message_write_line(1323, 12)
-#define BPMSG1079 bp_message_write_line(1335, 13)
-#define BPMSG1080 bp_message_write_buffer(1348, 8)
-#define BPMSG1081 bp_message_write_buffer(1356, 7)
-#define BPMSG1082 bp_message_write_line(1363, 21)
-#define BPMSG1083 bp_message_write_line(1384, 32)
-#define BPMSG1084 bp_message_write_buffer(1416, 7)
-#define BPMSG1085 bp_message_write_line(1423, 5)
-#define BPMSG1086 bp_message_write_line(1428, 22)
-#define BPMSG1087 bp_message_write_line(1450, 21)
-#define BPMSG1088 bp_message_write_line(1471, 29)
-#define BPMSG1089 bp_message_write_buffer(1500, 21)
-#define BPMSG1091 bp_message_write_buffer(1521, 20)
-#define BPMSG1092 bp_message_write_line(1541, 26)
-#define BPMSG1093 bp_message_write_line(1567, 5)
-#define BPMSG1094 bp_message_write_line(1572, 10)
-#define BPMSG1095 bp_message_write_buffer(1582, 22)
-#define BPMSG1096 bp_message_write_buffer(1604, 17)
-#define BPMSG1097 bp_message_write_buffer(1621, 18)
-#define BPMSG1098 bp_message_write_buffer(1639, 12)
-#define BPMSG1099 bp_message_write_buffer(1651, 6)
-#define BPMSG1100 bp_message_write_line(1657, 2)
-#define BPMSG1101 bp_message_write_buffer(1659, 7)
-#define BPMSG1102 bp_message_write_buffer(1666, 6)
-#define BPMSG1103 bp_message_write_line(1672, 8)
-#define BPMSG1104 bp_message_write_line(1680, 8)
-#define BPMSG1105 bp_message_write_line(1688, 14)
-#define BPMSG1106 bp_message_write_line(1702, 14)
-#define BPMSG1107 bp_message_write_line(1716, 16)
-#define BPMSG1108 bp_message_write_buffer(1732, 13)
-#define BPMSG1109 bp_message_write_buffer(1745, 10)
-#define BPMSG1110 bp_message_write_buffer(1755, 21)
-#define BPMSG1111 bp_message_write_line(1776, 23)
-#define BPMSG1112 bp_message_write_line(1799, 14)
-#define BPMSG1114 bp_message_write_line(1813, 21)
-#define BPMSG1115 bp_message_write_line(1834, 7)
-#define BPMSG1117 bp_message_write_buffer(1841, 6)
-#define BPMSG1118 bp_message_write_line(1847, 30)
-#define BPMSG1119 bp_message_write_line(1877, 12)
-#define BPMSG1120 bp_message_write_line(1889, 34)
-#define BPMSG1121 bp_message_write_line(1923, 30)
-#define BPMSG1123 bp_message_write_buffer(1953, 27)
-#define BPMSG1124 bp_message_write_buffer(1980, 28)
-#define BPMSG1127 bp_message_write_line(2008, 34)
-#define BPMSG1128 bp_message_write_line(2042, 18)
-#define BPMSG1133 bp_message_write_line(2060, 190)
-#define BPMSG1134 bp_message_write_line(2250, 20)
-#define BPMSG1135 bp_message_write_buffer(2270, 14)
-#define BPMSG1136 bp_message_write_buffer(2284, 5)
-#define BPMSG1137 bp_message_write_buffer(2289, 6)
-#define BPMSG1163 bp_message_write_line(2295, 46)
-#define BPMSG1164 bp_message_write_line(2341, 4)
-#define BPMSG1165 bp_message_write_buffer(2345, 3)
-#define BPMSG1166 bp_message_write_buffer(2348, 8)
-#define BPMSG1167 bp_message_write_buffer(2356, 8)
-#define BPMSG1168 bp_message_write_buffer(2364, 8)
-#define BPMSG1169 bp_message_write_buffer(2372, 4)
-#define BPMSG1170 bp_message_write_line(2376, 14)
-#define BPMSG1171 bp_message_write_buffer(2390, 2)
-#define BPMSG1172 bp_message_write_buffer(2392, 3)
-#define BPMSG1173 bp_message_write_buffer(2395, 4)
-#define BPMSG1174 bp_message_write_buffer(2399, 3)
-#define BPMSG1175 bp_message_write_line(2402, 8)
-#define BPMSG1176 bp_message_write_line(2410, 10)
-#define BPMSG1177 bp_message_write_line(2420, 10)
-#define BPMSG1178 bp_message_write_line(2430, 38)
-#define BPMSG1179 bp_message_write_buffer(2468, 6)
-#define BPMSG1180 bp_message_write_line(2474, 8)
-#define BPMSG1181 bp_message_write_buffer(2482, 4)
-#define BPMSG1182 bp_message_write_buffer(2486, 3)
-#define BPMSG1183 bp_message_write_buffer(2489, 4)
-#define BPMSG1184 bp_message_write_buffer(2493, 2)
-#define BPMSG1185 bp_message_write_line(2495, 3)
-#define BPMSG1186 bp_message_write_line(2498, 5)
-#define BPMSG1187 bp_message_write_line(2503, 154)
-#define BPMSG1188 bp_message_write_line(2657, 53)
-#define BPMSG1189 bp_message_write_line(2710, 67)
-#define BPMSG1190 bp_message_write_line(2777, 49)
-#define BPMSG1191 bp_message_write_buffer(2826, 32)
-#define BPMSG1192 bp_message_write_line(2858, 52)
-#define BPMSG1194 bp_message_write_buffer(2910, 3)
-#define BPMSG1195 bp_message_write_buffer(2913, 3)
-#define BPMSG1196 bp_message_write_buffer(2916, 15)
-#define BPMSG1197 bp_message_write_buffer(2931, 15)
-#define BPMSG1199 bp_message_write_buffer(2946, 84)
-#define BPMSG1200 bp_message_write_buffer(3030, 33)
-#define BPMSG1201 bp_message_write_buffer(3063, 50)
-#define BPMSG1202 bp_message_write_buffer(3113, 32)
-#define BPMSG1203 bp_message_write_buffer(3145, 124)
-#define BPMSG1204 bp_message_write_line(3269, 11)
-#define BPMSG1206 bp_message_write_line(3280, 14)
-#define BPMSG1207 bp_message_write_line(3294, 28)
-#define BPMSG1208 bp_message_write_line(3322, 20)
-#define BPMSG1209 bp_message_write_line(3342, 34)
-#define BPMSG1210 bp_message_write_buffer(3376, 7)
-#define BPMSG1211 bp_message_write_line(3383, 27)
-#define BPMSG1212 bp_message_write_line(3410, 2)
-#define BPMSG1213 bp_message_write_line(3412, 20)
-#define BPMSG1214 bp_message_write_line(3432, 18)
-#define BPMSG1216 bp_message_write_line(3450, 29)
-#define BPMSG1219 bp_message_write_line(3479, 152)
-#define BPMSG1220 bp_message_write_line(3631, 36)
-#define BPMSG1221 bp_message_write_line(3667, 4)
-#define BPMSG1222 bp_message_write_line(3671, 5)
-#define BPMSG1223 bp_message_write_line(3676, 10)
-#define BPMSG1226 bp_message_write_line(3686, 10)
-#define BPMSG1228 bp_message_write_buffer(3696, 10)
-#define BPMSG1234 bp_message_write_buffer(3706, 4)
-#define BPMSG1237 bp_message_write_buffer(3710, 8)
-#define BPMSG1238 bp_message_write_line(3718, 38)
-#define BPMSG1239 bp_message_write_line(3756, 28)
-#define BPMSG1240 bp_message_write_line(3784, 16)
-#define BPMSG1241 bp_message_write_line(3800, 14)
-#define BPMSG1242 bp_message_write_line(3814, 15)
-#define BPMSG1243 bp_message_write_line(3829, 5)
-#define BPMSG1244 bp_message_write_line(3834, 14)
-#define BPMSG1245 bp_message_write_buffer(3848, 11)
-#define BPMSG1248 bp_message_write_line(3859, 25)
-#define BPMSG1250 bp_message_write_line(3884, 15)
-#define BPMSG1251 bp_message_write_line(3899, 17)
-#define BPMSG1252 bp_message_write_buffer(3916, 27)
-#define BPMSG1254 bp_message_write_line(3943, 19)
-#define BPMSG1255 bp_message_write_line(3962, 12)
-#define BPMSG1256 bp_message_write_line(3974, 86)
-#define BPMSG1257 bp_message_write_buffer(4060, 36)
-#define BPMSG1259 bp_message_write_line(4096, 9)
-#define BPMSG1262 bp_message_write_line(4105, 11)
-#define BPMSG1263 bp_message_write_line(4116, 23)
-#define BPMSG1264 bp_message_write_line(4139, 23)
-#define BPMSG1265 bp_message_write_line(4162, 6)
-#define BPMSG1266 bp_message_write_buffer(4168, 3)
-#define BPMSG1267 bp_message_write_buffer(4171, 3)
-#define BPMSG1268 bp_message_write_buffer(4174, 2)
-#define BPMSG1269 bp_message_write_buffer(4176, 10)
-#define BPMSG1270 bp_message_write_buffer(4186, 4)
-#define BPMSG1271 bp_message_write_line(4190, 87)
-#define BPMSG1272 bp_message_write_buffer(4277, 25)
-#define BPMSG1273 bp_message_write_line(4302, 7)
-#define BPMSG1274 bp_message_write_line(4309, 8)
-#define BPMSG1280 bp_message_write_line(4317, 19)
-#define BPMSG1281 bp_message_write_line(4336, 14)
-#define BPMSG1282 bp_message_write_line(4350, 56)
-#define BPMSG1283 bp_message_write_buffer(4406, 15)
-#define BPMSG1284 bp_message_write_buffer(4421, 15)
-#define BPMSG1285 bp_message_write_line(4436, 4)
-#define HLP1000 bp_message_write_line(4440, 32)
-#define HLP1001 bp_message_write_line(4472, 75)
-#define HLP1002 bp_message_write_line(4547, 37)
-#define HLP1003 bp_message_write_line(4584, 39)
-#define HLP1004 bp_message_write_line(4623, 20)
-#define HLP1005 bp_message_write_line(4643, 26)
-#define HLP1006 bp_message_write_line(4669, 39)
-#define HLP1007 bp_message_write_line(4708, 26)
-#define HLP1008 bp_message_write_line(4734, 45)
-#define HLP1009 bp_message_write_line(4779, 39)
-#define HLP1010 bp_message_write_line(4818, 57)
-#define HLP1011 bp_message_write_line(4875, 52)
-#define HLP1012 bp_message_write_line(4927, 27)
-#define HLP1013 bp_message_write_line(4954, 32)
-#define HLP1014 bp_message_write_line(4986, 27)
-#define HLP1015 bp_message_write_line(5013, 36)
-#define HLP1016 bp_message_write_line(5049, 32)
-#define HLP1017 bp_message_write_line(5081, 24)
-#define HLP1018 bp_message_write_line(5105, 31)
-#define HLP1019 bp_message_write_line(5136, 40)
-#define HLP1020 bp_message_write_line(5176, 36)
-#define HLP1021 bp_message_write_line(5212, 53)
-#define HLP1022 bp_message_write_line(5265, 61)
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(5326, 4)
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(5330, 62)
-#define MSG_ACK bp_message_write_buffer(5392, 3)
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(5395, 3)
-#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(5398, 25)
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(5423, 5)
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(5428, 2)
-#define MSG_CFG0_FIELD bp_message_write_buffer(5430, 6)
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(5436, 2)
-#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(5438, 2)
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(5440, 15)
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(5455, 3)
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(5458, 20)
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(5478, 17)
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(5495, 61)
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(5556, 2)
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(5558, 4)
-#define MSG_I2C_PINS_STATE bp_message_write_line(5562, 11)
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(5573, 4)
-#define MSG_I2C_START_BIT bp_message_write_line(5577, 13)
-#define MSG_I2C_STOP_BIT bp_message_write_line(5590, 12)
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(5602, 4)
-#define MSG_MODE_HEADER_END bp_message_write_line(5606, 2)
-#define MSG_NACK bp_message_write_buffer(5608, 4)
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(5612, 34)
-#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(5646, 38)
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(5684, 4)
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(5688, 12)
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(5700, 79)
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(5779, 36)
-#define MSG_PWM_HZ_MARKER bp_message_write_line(5815, 3)
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(5818, 12)
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(5830, 13)
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(5843, 25)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(5868, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(5874, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(5880, 10)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(5890, 6)
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(5896, 7)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(5903, 11)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(5914, 6)
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(5920, 15)
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(5935, 45)
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(5980, 3)
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(5983, 63)
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(6046, 8)
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(6054, 6)
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(6060, 56)
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(6116, 16)
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(6132, 20)
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(6152, 23)
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(6175, 4)
-#define MSG_RESET_MESSAGE bp_message_write_line(6179, 5)
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(6184, 59)
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(6243, 16)
-#define MSG_SPI_CS_DISABLED bp_message_write_line(6259, 11)
-#define MSG_SPI_CS_ENABLED bp_message_write_line(6270, 10)
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(6280, 29)
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(6309, 4)
-#define MSG_SPI_PINS_STATE bp_message_write_line(6313, 16)
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(6329, 4)
-#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(6333, 14)
-#define MSG_UART_PINS_STATE bp_message_write_line(6347, 11)
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(6358, 36)
-#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(6394, 39)
-#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(6433, 41)
-#define MSG_VPU_3V3_MARKER bp_message_write_buffer(6474, 9)
-#define MSG_VPU_5V_MARKER bp_message_write_buffer(6483, 8)
-#define MSG_VREG_TOO_LOW bp_message_write_line(6491, 31)
-#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(6522, 4)
+void BPMSG1001_str(void);
+#define BPMSG1001 bp_message_write_line(BPMSG1001_str, 36)
+void BPMSG1004_str(void);
+#define BPMSG1004 bp_message_write_line(BPMSG1004_str, 41)
+void BPMSG1005_str(void);
+#define BPMSG1005 bp_message_write_buffer(BPMSG1005_str, 14)
+void BPMSG1006_str(void);
+#define BPMSG1006 bp_message_write_line(BPMSG1006_str, 13)
+void BPMSG1007_str(void);
+#define BPMSG1007 bp_message_write_line(BPMSG1007_str, 23)
+void BPMSG1008_str(void);
+#define BPMSG1008 bp_message_write_buffer(BPMSG1008_str, 6)
+void BPMSG1009_str(void);
+#define BPMSG1009 bp_message_write_line(BPMSG1009_str, 211)
+void BPMSG1010_str(void);
+#define BPMSG1010 bp_message_write_line(BPMSG1010_str, 19)
+void BPMSG1011_str(void);
+#define BPMSG1011 bp_message_write_line(BPMSG1011_str, 13)
+void BPMSG1012_str(void);
+#define BPMSG1012 bp_message_write_line(BPMSG1012_str, 43)
+void BPMSG1013_str(void);
+#define BPMSG1013 bp_message_write_buffer(BPMSG1013_str, 17)
+void BPMSG1014_str(void);
+#define BPMSG1014 bp_message_write_line(BPMSG1014_str, 16)
+void BPMSG1015_str(void);
+#define BPMSG1015 bp_message_write_line(BPMSG1015_str, 15)
+void BPMSG1017_str(void);
+#define BPMSG1017 bp_message_write_buffer(BPMSG1017_str, 10)
+void BPMSG1019_str(void);
+#define BPMSG1019 bp_message_write_buffer(BPMSG1019_str, 9)
+void BPMSG1020_str(void);
+#define BPMSG1020 bp_message_write_buffer(BPMSG1020_str, 21)
+void BPMSG1021_str(void);
+#define BPMSG1021 bp_message_write_buffer(BPMSG1021_str, 20)
+void BPMSG1022_str(void);
+#define BPMSG1022 bp_message_write_buffer(BPMSG1022_str, 27)
+void BPMSG1023_str(void);
+#define BPMSG1023 bp_message_write_buffer(BPMSG1023_str, 26)
+void BPMSG1024_str(void);
+#define BPMSG1024 bp_message_write_buffer(BPMSG1024_str, 21)
+void BPMSG1025_str(void);
+#define BPMSG1025 bp_message_write_buffer(BPMSG1025_str, 24)
+void BPMSG1026_str(void);
+#define BPMSG1026 bp_message_write_buffer(BPMSG1026_str, 16)
+void BPMSG1027_str(void);
+#define BPMSG1027 bp_message_write_buffer(BPMSG1027_str, 14)
+void BPMSG1028_str(void);
+#define BPMSG1028 bp_message_write_line(BPMSG1028_str, 12)
+void BPMSG1029_str(void);
+#define BPMSG1029 bp_message_write_line(BPMSG1029_str, 17)
+void BPMSG1030_str(void);
+#define BPMSG1030 bp_message_write_buffer(BPMSG1030_str, 17)
+void BPMSG1033_str(void);
+#define BPMSG1033 bp_message_write_buffer(BPMSG1033_str, 16)
+void BPMSG1034_str(void);
+#define BPMSG1034 bp_message_write_line(BPMSG1034_str, 10)
+void BPMSG1037_str(void);
+#define BPMSG1037 bp_message_write_line(BPMSG1037_str, 31)
+void BPMSG1038_str(void);
+#define BPMSG1038 bp_message_write_buffer(BPMSG1038_str, 15)
+void BPMSG1039_str(void);
+#define BPMSG1039 bp_message_write_buffer(BPMSG1039_str, 14)
+void BPMSG1040_str(void);
+#define BPMSG1040 bp_message_write_line(BPMSG1040_str, 8)
+void BPMSG1041_str(void);
+#define BPMSG1041 bp_message_write_line(BPMSG1041_str, 7)
+void BPMSG1042_str(void);
+#define BPMSG1042 bp_message_write_line(BPMSG1042_str, 14)
+void BPMSG1044_str(void);
+#define BPMSG1044 bp_message_write_buffer(BPMSG1044_str, 15)
+void BPMSG1045_str(void);
+#define BPMSG1045 bp_message_write_buffer(BPMSG1045_str, 1)
+void BPMSG1047_str(void);
+#define BPMSG1047 bp_message_write_buffer(BPMSG1047_str, 6)
+void BPMSG1048_str(void);
+#define BPMSG1048 bp_message_write_buffer(BPMSG1048_str, 8)
+void BPMSG1049_str(void);
+#define BPMSG1049 bp_message_write_buffer(BPMSG1049_str, 11)
+void BPMSG1050_str(void);
+#define BPMSG1050 bp_message_write_line(BPMSG1050_str, 7)
+void BPMSG1051_str(void);
+#define BPMSG1051 bp_message_write_line(BPMSG1051_str, 9)
+void BPMSG1052_str(void);
+#define BPMSG1052 bp_message_write_line(BPMSG1052_str, 12)
+void BPMSG1053_str(void);
+#define BPMSG1053 bp_message_write_line(BPMSG1053_str, 9)
+void BPMSG1054_str(void);
+#define BPMSG1054 bp_message_write_buffer(BPMSG1054_str, 7)
+void BPMSG1055_str(void);
+#define BPMSG1055 bp_message_write_line(BPMSG1055_str, 4)
+void BPMSG1056_str(void);
+#define BPMSG1056 bp_message_write_buffer(BPMSG1056_str, 15)
+void BPMSG1057_str(void);
+#define BPMSG1057 bp_message_write_line(BPMSG1057_str, 12)
+void BPMSG1058_str(void);
+#define BPMSG1058 bp_message_write_buffer(BPMSG1058_str, 18)
+void BPMSG1059_str(void);
+#define BPMSG1059 bp_message_write_line(BPMSG1059_str, 33)
+void BPMSG1064_str(void);
+#define BPMSG1064 bp_message_write_line(BPMSG1064_str, 37)
+void BPMSG1067_str(void);
+#define BPMSG1067 bp_message_write_buffer(BPMSG1067_str, 44)
+void BPMSG1068_str(void);
+#define BPMSG1068 bp_message_write_buffer(BPMSG1068_str, 16)
+void BPMSG1069_str(void);
+#define BPMSG1069 bp_message_write_buffer(BPMSG1069_str, 123)
+void BPMSG1070_str(void);
+#define BPMSG1070 bp_message_write_line(BPMSG1070_str, 46)
+void BPMSG1071_str(void);
+#define BPMSG1071 bp_message_write_line(BPMSG1071_str, 7)
+void BPMSG1072_str(void);
+#define BPMSG1072 bp_message_write_line(BPMSG1072_str, 34)
+void BPMSG1073_str(void);
+#define BPMSG1073 bp_message_write_line(BPMSG1073_str, 6)
+void BPMSG1074_str(void);
+#define BPMSG1074 bp_message_write_buffer(BPMSG1074_str, 14)
+void BPMSG1075_str(void);
+#define BPMSG1075 bp_message_write_buffer(BPMSG1075_str, 3)
+void BPMSG1076_str(void);
+#define BPMSG1076 bp_message_write_line(BPMSG1076_str, 3)
+void BPMSG1077_str(void);
+#define BPMSG1077 bp_message_write_line(BPMSG1077_str, 7)
+void BPMSG1078_str(void);
+#define BPMSG1078 bp_message_write_line(BPMSG1078_str, 12)
+void BPMSG1079_str(void);
+#define BPMSG1079 bp_message_write_line(BPMSG1079_str, 13)
+void BPMSG1080_str(void);
+#define BPMSG1080 bp_message_write_buffer(BPMSG1080_str, 8)
+void BPMSG1081_str(void);
+#define BPMSG1081 bp_message_write_buffer(BPMSG1081_str, 7)
+void BPMSG1082_str(void);
+#define BPMSG1082 bp_message_write_line(BPMSG1082_str, 21)
+void BPMSG1083_str(void);
+#define BPMSG1083 bp_message_write_line(BPMSG1083_str, 32)
+void BPMSG1084_str(void);
+#define BPMSG1084 bp_message_write_buffer(BPMSG1084_str, 7)
+void BPMSG1085_str(void);
+#define BPMSG1085 bp_message_write_line(BPMSG1085_str, 5)
+void BPMSG1086_str(void);
+#define BPMSG1086 bp_message_write_line(BPMSG1086_str, 22)
+void BPMSG1087_str(void);
+#define BPMSG1087 bp_message_write_line(BPMSG1087_str, 21)
+void BPMSG1088_str(void);
+#define BPMSG1088 bp_message_write_line(BPMSG1088_str, 29)
+void BPMSG1089_str(void);
+#define BPMSG1089 bp_message_write_buffer(BPMSG1089_str, 21)
+void BPMSG1091_str(void);
+#define BPMSG1091 bp_message_write_buffer(BPMSG1091_str, 20)
+void BPMSG1092_str(void);
+#define BPMSG1092 bp_message_write_line(BPMSG1092_str, 26)
+void BPMSG1093_str(void);
+#define BPMSG1093 bp_message_write_line(BPMSG1093_str, 5)
+void BPMSG1094_str(void);
+#define BPMSG1094 bp_message_write_line(BPMSG1094_str, 10)
+void BPMSG1095_str(void);
+#define BPMSG1095 bp_message_write_buffer(BPMSG1095_str, 22)
+void BPMSG1096_str(void);
+#define BPMSG1096 bp_message_write_buffer(BPMSG1096_str, 17)
+void BPMSG1097_str(void);
+#define BPMSG1097 bp_message_write_buffer(BPMSG1097_str, 18)
+void BPMSG1098_str(void);
+#define BPMSG1098 bp_message_write_buffer(BPMSG1098_str, 12)
+void BPMSG1099_str(void);
+#define BPMSG1099 bp_message_write_buffer(BPMSG1099_str, 6)
+void BPMSG1100_str(void);
+#define BPMSG1100 bp_message_write_line(BPMSG1100_str, 2)
+void BPMSG1101_str(void);
+#define BPMSG1101 bp_message_write_buffer(BPMSG1101_str, 7)
+void BPMSG1102_str(void);
+#define BPMSG1102 bp_message_write_buffer(BPMSG1102_str, 6)
+void BPMSG1103_str(void);
+#define BPMSG1103 bp_message_write_line(BPMSG1103_str, 8)
+void BPMSG1104_str(void);
+#define BPMSG1104 bp_message_write_line(BPMSG1104_str, 8)
+void BPMSG1105_str(void);
+#define BPMSG1105 bp_message_write_line(BPMSG1105_str, 14)
+void BPMSG1106_str(void);
+#define BPMSG1106 bp_message_write_line(BPMSG1106_str, 14)
+void BPMSG1107_str(void);
+#define BPMSG1107 bp_message_write_line(BPMSG1107_str, 16)
+void BPMSG1108_str(void);
+#define BPMSG1108 bp_message_write_buffer(BPMSG1108_str, 13)
+void BPMSG1109_str(void);
+#define BPMSG1109 bp_message_write_buffer(BPMSG1109_str, 10)
+void BPMSG1110_str(void);
+#define BPMSG1110 bp_message_write_buffer(BPMSG1110_str, 21)
+void BPMSG1111_str(void);
+#define BPMSG1111 bp_message_write_line(BPMSG1111_str, 23)
+void BPMSG1112_str(void);
+#define BPMSG1112 bp_message_write_line(BPMSG1112_str, 14)
+void BPMSG1114_str(void);
+#define BPMSG1114 bp_message_write_line(BPMSG1114_str, 21)
+void BPMSG1115_str(void);
+#define BPMSG1115 bp_message_write_line(BPMSG1115_str, 7)
+void BPMSG1117_str(void);
+#define BPMSG1117 bp_message_write_buffer(BPMSG1117_str, 6)
+void BPMSG1118_str(void);
+#define BPMSG1118 bp_message_write_line(BPMSG1118_str, 30)
+void BPMSG1119_str(void);
+#define BPMSG1119 bp_message_write_line(BPMSG1119_str, 12)
+void BPMSG1120_str(void);
+#define BPMSG1120 bp_message_write_line(BPMSG1120_str, 34)
+void BPMSG1121_str(void);
+#define BPMSG1121 bp_message_write_line(BPMSG1121_str, 30)
+void BPMSG1123_str(void);
+#define BPMSG1123 bp_message_write_buffer(BPMSG1123_str, 27)
+void BPMSG1124_str(void);
+#define BPMSG1124 bp_message_write_buffer(BPMSG1124_str, 28)
+void BPMSG1127_str(void);
+#define BPMSG1127 bp_message_write_line(BPMSG1127_str, 34)
+void BPMSG1128_str(void);
+#define BPMSG1128 bp_message_write_line(BPMSG1128_str, 18)
+void BPMSG1133_str(void);
+#define BPMSG1133 bp_message_write_line(BPMSG1133_str, 190)
+void BPMSG1134_str(void);
+#define BPMSG1134 bp_message_write_line(BPMSG1134_str, 20)
+void BPMSG1135_str(void);
+#define BPMSG1135 bp_message_write_buffer(BPMSG1135_str, 14)
+void BPMSG1136_str(void);
+#define BPMSG1136 bp_message_write_buffer(BPMSG1136_str, 5)
+void BPMSG1137_str(void);
+#define BPMSG1137 bp_message_write_buffer(BPMSG1137_str, 6)
+void BPMSG1163_str(void);
+#define BPMSG1163 bp_message_write_line(BPMSG1163_str, 46)
+void BPMSG1164_str(void);
+#define BPMSG1164 bp_message_write_line(BPMSG1164_str, 4)
+void BPMSG1165_str(void);
+#define BPMSG1165 bp_message_write_buffer(BPMSG1165_str, 3)
+void BPMSG1166_str(void);
+#define BPMSG1166 bp_message_write_buffer(BPMSG1166_str, 8)
+void BPMSG1167_str(void);
+#define BPMSG1167 bp_message_write_buffer(BPMSG1167_str, 8)
+void BPMSG1168_str(void);
+#define BPMSG1168 bp_message_write_buffer(BPMSG1168_str, 8)
+void BPMSG1169_str(void);
+#define BPMSG1169 bp_message_write_buffer(BPMSG1169_str, 4)
+void BPMSG1170_str(void);
+#define BPMSG1170 bp_message_write_line(BPMSG1170_str, 14)
+void BPMSG1171_str(void);
+#define BPMSG1171 bp_message_write_buffer(BPMSG1171_str, 2)
+void BPMSG1172_str(void);
+#define BPMSG1172 bp_message_write_buffer(BPMSG1172_str, 3)
+void BPMSG1173_str(void);
+#define BPMSG1173 bp_message_write_buffer(BPMSG1173_str, 4)
+void BPMSG1174_str(void);
+#define BPMSG1174 bp_message_write_buffer(BPMSG1174_str, 3)
+void BPMSG1175_str(void);
+#define BPMSG1175 bp_message_write_line(BPMSG1175_str, 8)
+void BPMSG1176_str(void);
+#define BPMSG1176 bp_message_write_line(BPMSG1176_str, 10)
+void BPMSG1177_str(void);
+#define BPMSG1177 bp_message_write_line(BPMSG1177_str, 10)
+void BPMSG1178_str(void);
+#define BPMSG1178 bp_message_write_line(BPMSG1178_str, 38)
+void BPMSG1179_str(void);
+#define BPMSG1179 bp_message_write_buffer(BPMSG1179_str, 6)
+void BPMSG1180_str(void);
+#define BPMSG1180 bp_message_write_line(BPMSG1180_str, 8)
+void BPMSG1181_str(void);
+#define BPMSG1181 bp_message_write_buffer(BPMSG1181_str, 4)
+void BPMSG1182_str(void);
+#define BPMSG1182 bp_message_write_buffer(BPMSG1182_str, 3)
+void BPMSG1183_str(void);
+#define BPMSG1183 bp_message_write_buffer(BPMSG1183_str, 4)
+void BPMSG1184_str(void);
+#define BPMSG1184 bp_message_write_buffer(BPMSG1184_str, 2)
+void BPMSG1185_str(void);
+#define BPMSG1185 bp_message_write_line(BPMSG1185_str, 3)
+void BPMSG1186_str(void);
+#define BPMSG1186 bp_message_write_line(BPMSG1186_str, 5)
+void BPMSG1187_str(void);
+#define BPMSG1187 bp_message_write_line(BPMSG1187_str, 154)
+void BPMSG1188_str(void);
+#define BPMSG1188 bp_message_write_line(BPMSG1188_str, 53)
+void BPMSG1189_str(void);
+#define BPMSG1189 bp_message_write_line(BPMSG1189_str, 67)
+void BPMSG1190_str(void);
+#define BPMSG1190 bp_message_write_line(BPMSG1190_str, 49)
+void BPMSG1191_str(void);
+#define BPMSG1191 bp_message_write_buffer(BPMSG1191_str, 32)
+void BPMSG1192_str(void);
+#define BPMSG1192 bp_message_write_line(BPMSG1192_str, 52)
+void BPMSG1194_str(void);
+#define BPMSG1194 bp_message_write_buffer(BPMSG1194_str, 3)
+void BPMSG1195_str(void);
+#define BPMSG1195 bp_message_write_buffer(BPMSG1195_str, 3)
+void BPMSG1196_str(void);
+#define BPMSG1196 bp_message_write_buffer(BPMSG1196_str, 15)
+void BPMSG1197_str(void);
+#define BPMSG1197 bp_message_write_buffer(BPMSG1197_str, 15)
+void BPMSG1199_str(void);
+#define BPMSG1199 bp_message_write_buffer(BPMSG1199_str, 84)
+void BPMSG1200_str(void);
+#define BPMSG1200 bp_message_write_buffer(BPMSG1200_str, 33)
+void BPMSG1201_str(void);
+#define BPMSG1201 bp_message_write_buffer(BPMSG1201_str, 50)
+void BPMSG1202_str(void);
+#define BPMSG1202 bp_message_write_buffer(BPMSG1202_str, 32)
+void BPMSG1203_str(void);
+#define BPMSG1203 bp_message_write_buffer(BPMSG1203_str, 124)
+void BPMSG1204_str(void);
+#define BPMSG1204 bp_message_write_line(BPMSG1204_str, 11)
+void BPMSG1206_str(void);
+#define BPMSG1206 bp_message_write_line(BPMSG1206_str, 14)
+void BPMSG1207_str(void);
+#define BPMSG1207 bp_message_write_line(BPMSG1207_str, 28)
+void BPMSG1208_str(void);
+#define BPMSG1208 bp_message_write_line(BPMSG1208_str, 20)
+void BPMSG1209_str(void);
+#define BPMSG1209 bp_message_write_line(BPMSG1209_str, 34)
+void BPMSG1210_str(void);
+#define BPMSG1210 bp_message_write_buffer(BPMSG1210_str, 7)
+void BPMSG1211_str(void);
+#define BPMSG1211 bp_message_write_line(BPMSG1211_str, 27)
+void BPMSG1212_str(void);
+#define BPMSG1212 bp_message_write_line(BPMSG1212_str, 2)
+void BPMSG1213_str(void);
+#define BPMSG1213 bp_message_write_line(BPMSG1213_str, 20)
+void BPMSG1214_str(void);
+#define BPMSG1214 bp_message_write_line(BPMSG1214_str, 18)
+void BPMSG1216_str(void);
+#define BPMSG1216 bp_message_write_line(BPMSG1216_str, 29)
+void BPMSG1219_str(void);
+#define BPMSG1219 bp_message_write_line(BPMSG1219_str, 152)
+void BPMSG1220_str(void);
+#define BPMSG1220 bp_message_write_line(BPMSG1220_str, 36)
+void BPMSG1221_str(void);
+#define BPMSG1221 bp_message_write_line(BPMSG1221_str, 4)
+void BPMSG1222_str(void);
+#define BPMSG1222 bp_message_write_line(BPMSG1222_str, 5)
+void BPMSG1223_str(void);
+#define BPMSG1223 bp_message_write_line(BPMSG1223_str, 10)
+void BPMSG1226_str(void);
+#define BPMSG1226 bp_message_write_line(BPMSG1226_str, 10)
+void BPMSG1228_str(void);
+#define BPMSG1228 bp_message_write_buffer(BPMSG1228_str, 10)
+void BPMSG1234_str(void);
+#define BPMSG1234 bp_message_write_buffer(BPMSG1234_str, 4)
+void BPMSG1237_str(void);
+#define BPMSG1237 bp_message_write_buffer(BPMSG1237_str, 8)
+void BPMSG1238_str(void);
+#define BPMSG1238 bp_message_write_line(BPMSG1238_str, 38)
+void BPMSG1239_str(void);
+#define BPMSG1239 bp_message_write_line(BPMSG1239_str, 28)
+void BPMSG1240_str(void);
+#define BPMSG1240 bp_message_write_line(BPMSG1240_str, 16)
+void BPMSG1241_str(void);
+#define BPMSG1241 bp_message_write_line(BPMSG1241_str, 14)
+void BPMSG1242_str(void);
+#define BPMSG1242 bp_message_write_line(BPMSG1242_str, 15)
+void BPMSG1243_str(void);
+#define BPMSG1243 bp_message_write_line(BPMSG1243_str, 5)
+void BPMSG1244_str(void);
+#define BPMSG1244 bp_message_write_line(BPMSG1244_str, 14)
+void BPMSG1245_str(void);
+#define BPMSG1245 bp_message_write_buffer(BPMSG1245_str, 11)
+void BPMSG1248_str(void);
+#define BPMSG1248 bp_message_write_line(BPMSG1248_str, 25)
+void BPMSG1250_str(void);
+#define BPMSG1250 bp_message_write_line(BPMSG1250_str, 15)
+void BPMSG1251_str(void);
+#define BPMSG1251 bp_message_write_line(BPMSG1251_str, 17)
+void BPMSG1252_str(void);
+#define BPMSG1252 bp_message_write_buffer(BPMSG1252_str, 27)
+void BPMSG1254_str(void);
+#define BPMSG1254 bp_message_write_line(BPMSG1254_str, 19)
+void BPMSG1255_str(void);
+#define BPMSG1255 bp_message_write_line(BPMSG1255_str, 12)
+void BPMSG1256_str(void);
+#define BPMSG1256 bp_message_write_line(BPMSG1256_str, 86)
+void BPMSG1257_str(void);
+#define BPMSG1257 bp_message_write_buffer(BPMSG1257_str, 36)
+void BPMSG1259_str(void);
+#define BPMSG1259 bp_message_write_line(BPMSG1259_str, 9)
+void BPMSG1262_str(void);
+#define BPMSG1262 bp_message_write_line(BPMSG1262_str, 11)
+void BPMSG1263_str(void);
+#define BPMSG1263 bp_message_write_line(BPMSG1263_str, 23)
+void BPMSG1264_str(void);
+#define BPMSG1264 bp_message_write_line(BPMSG1264_str, 23)
+void BPMSG1265_str(void);
+#define BPMSG1265 bp_message_write_line(BPMSG1265_str, 6)
+void BPMSG1266_str(void);
+#define BPMSG1266 bp_message_write_buffer(BPMSG1266_str, 3)
+void BPMSG1267_str(void);
+#define BPMSG1267 bp_message_write_buffer(BPMSG1267_str, 3)
+void BPMSG1268_str(void);
+#define BPMSG1268 bp_message_write_buffer(BPMSG1268_str, 2)
+void BPMSG1269_str(void);
+#define BPMSG1269 bp_message_write_buffer(BPMSG1269_str, 10)
+void BPMSG1270_str(void);
+#define BPMSG1270 bp_message_write_buffer(BPMSG1270_str, 4)
+void BPMSG1271_str(void);
+#define BPMSG1271 bp_message_write_line(BPMSG1271_str, 87)
+void BPMSG1272_str(void);
+#define BPMSG1272 bp_message_write_buffer(BPMSG1272_str, 25)
+void BPMSG1273_str(void);
+#define BPMSG1273 bp_message_write_line(BPMSG1273_str, 7)
+void BPMSG1274_str(void);
+#define BPMSG1274 bp_message_write_line(BPMSG1274_str, 8)
+void BPMSG1280_str(void);
+#define BPMSG1280 bp_message_write_line(BPMSG1280_str, 19)
+void BPMSG1281_str(void);
+#define BPMSG1281 bp_message_write_line(BPMSG1281_str, 14)
+void BPMSG1282_str(void);
+#define BPMSG1282 bp_message_write_line(BPMSG1282_str, 56)
+void BPMSG1283_str(void);
+#define BPMSG1283 bp_message_write_buffer(BPMSG1283_str, 15)
+void BPMSG1284_str(void);
+#define BPMSG1284 bp_message_write_buffer(BPMSG1284_str, 15)
+void BPMSG1285_str(void);
+#define BPMSG1285 bp_message_write_line(BPMSG1285_str, 4)
+void HLP1000_str(void);
+#define HLP1000 bp_message_write_line(HLP1000_str, 32)
+void HLP1001_str(void);
+#define HLP1001 bp_message_write_line(HLP1001_str, 75)
+void HLP1002_str(void);
+#define HLP1002 bp_message_write_line(HLP1002_str, 37)
+void HLP1003_str(void);
+#define HLP1003 bp_message_write_line(HLP1003_str, 39)
+void HLP1004_str(void);
+#define HLP1004 bp_message_write_line(HLP1004_str, 20)
+void HLP1005_str(void);
+#define HLP1005 bp_message_write_line(HLP1005_str, 26)
+void HLP1006_str(void);
+#define HLP1006 bp_message_write_line(HLP1006_str, 39)
+void HLP1007_str(void);
+#define HLP1007 bp_message_write_line(HLP1007_str, 26)
+void HLP1008_str(void);
+#define HLP1008 bp_message_write_line(HLP1008_str, 45)
+void HLP1009_str(void);
+#define HLP1009 bp_message_write_line(HLP1009_str, 39)
+void HLP1010_str(void);
+#define HLP1010 bp_message_write_line(HLP1010_str, 57)
+void HLP1011_str(void);
+#define HLP1011 bp_message_write_line(HLP1011_str, 52)
+void HLP1012_str(void);
+#define HLP1012 bp_message_write_line(HLP1012_str, 27)
+void HLP1013_str(void);
+#define HLP1013 bp_message_write_line(HLP1013_str, 32)
+void HLP1014_str(void);
+#define HLP1014 bp_message_write_line(HLP1014_str, 27)
+void HLP1015_str(void);
+#define HLP1015 bp_message_write_line(HLP1015_str, 36)
+void HLP1016_str(void);
+#define HLP1016 bp_message_write_line(HLP1016_str, 32)
+void HLP1017_str(void);
+#define HLP1017 bp_message_write_line(HLP1017_str, 24)
+void HLP1018_str(void);
+#define HLP1018 bp_message_write_line(HLP1018_str, 31)
+void HLP1019_str(void);
+#define HLP1019 bp_message_write_line(HLP1019_str, 40)
+void HLP1020_str(void);
+#define HLP1020 bp_message_write_line(HLP1020_str, 36)
+void HLP1021_str(void);
+#define HLP1021 bp_message_write_line(HLP1021_str, 53)
+void HLP1022_str(void);
+#define HLP1022 bp_message_write_line(HLP1022_str, 61)
+void MSG_1WIRE_MODE_IDENTIFIER_str(void);
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(MSG_1WIRE_MODE_IDENTIFIER_str, 4)
+void MSG_1WIRE_SPEED_PROMPT_str(void);
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(MSG_1WIRE_SPEED_PROMPT_str, 62)
+void MSG_ACK_str(void);
+#define MSG_ACK bp_message_write_buffer(MSG_ACK_str, 3)
+void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(MSG_BASE_CONVERTER_EQUAL_SIGN_str, 3)
+void MSG_BAUD_DETECTION_SELECTED_str(void);
+#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(MSG_BAUD_DETECTION_SELECTED_str, 25)
+void MSG_BBIO_MODE_IDENTIFIER_str(void);
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(MSG_BBIO_MODE_IDENTIFIER_str, 5)
+void MSG_BINARY_NUMBER_PREFIX_str(void);
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(MSG_BINARY_NUMBER_PREFIX_str, 2)
+void MSG_CFG0_FIELD_str(void);
+#define MSG_CFG0_FIELD bp_message_write_buffer(MSG_CFG0_FIELD_str, 6)
+void MSG_CHIP_REVISION_A3_str(void);
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(MSG_CHIP_REVISION_A3_str, 2)
+void MSG_CHIP_REVISION_A5_str(void);
+#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(MSG_CHIP_REVISION_A5_str, 2)
+void MSG_CHIP_REVISION_ID_BEGIN_str(void);
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(MSG_CHIP_REVISION_ID_BEGIN_str, 15)
+void MSG_CHIP_REVISION_UNKNOWN_str(void);
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(MSG_CHIP_REVISION_UNKNOWN_str, 3)
+void MSG_CLUTCH_DISENGAGED_str(void);
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(MSG_CLUTCH_DISENGAGED_str, 20)
+void MSG_CLUTCH_ENGAGED_str(void);
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(MSG_CLUTCH_ENGAGED_str, 17)
+void MSG_FINISH_SETUP_PROMPT_str(void);
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(MSG_FINISH_SETUP_PROMPT_str, 61)
+void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(MSG_HEXADECIMAL_NUMBER_PREFIX_str, 2)
+void MSG_I2C_MODE_IDENTIFIER_str(void);
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(MSG_I2C_MODE_IDENTIFIER_str, 4)
+void MSG_I2C_PINS_STATE_str(void);
+#define MSG_I2C_PINS_STATE bp_message_write_line(MSG_I2C_PINS_STATE_str, 11)
+void MSG_I2C_READ_ADDRESS_END_str(void);
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(MSG_I2C_READ_ADDRESS_END_str, 4)
+void MSG_I2C_START_BIT_str(void);
+#define MSG_I2C_START_BIT bp_message_write_line(MSG_I2C_START_BIT_str, 13)
+void MSG_I2C_STOP_BIT_str(void);
+#define MSG_I2C_STOP_BIT bp_message_write_line(MSG_I2C_STOP_BIT_str, 12)
+void MSG_I2C_WRITE_ADDRESS_END_str(void);
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(MSG_I2C_WRITE_ADDRESS_END_str, 4)
+void MSG_MODE_HEADER_END_str(void);
+#define MSG_MODE_HEADER_END bp_message_write_line(MSG_MODE_HEADER_END_str, 2)
+void MSG_NACK_str(void);
+#define MSG_NACK bp_message_write_buffer(MSG_NACK_str, 4)
+void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str, 34)
+void MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str(void);
+#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str, 38)
+void MSG_PIC_MODE_IDENTIFIER_str(void);
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(MSG_PIC_MODE_IDENTIFIER_str, 4)
+void MSG_PIC_UNKNOWN_MODE_str(void);
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(MSG_PIC_UNKNOWN_MODE_str, 12)
+void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(MSG_PIN_OUTPUT_TYPE_PROMPT_str, 79)
+void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(MSG_PWM_FREQUENCY_TOO_LOW_str, 36)
+void MSG_PWM_HZ_MARKER_str(void);
+#define MSG_PWM_HZ_MARKER bp_message_write_line(MSG_PWM_HZ_MARKER_str, 3)
+void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str, 12)
+void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str, 13)
+void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str, 25)
+void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str, 10)
+void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str, 6)
+void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str, 7)
+void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str, 11)
+void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str, 6)
+void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str, 15)
+void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_REPLY_HEADER_str, 45)
+void MSG_RAW2WIRE_ATR_RFU_str(void);
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(MSG_RAW2WIRE_ATR_RFU_str, 3)
+void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str, 63)
+void MSG_RAW2WIRE_I2C_START_str(void);
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(MSG_RAW2WIRE_I2C_START_str, 8)
+void MSG_RAW2WIRE_I2C_STOP_str(void);
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(MSG_RAW2WIRE_I2C_STOP_str, 6)
+void MSG_RAW2WIRE_MACRO_MENU_str(void);
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(MSG_RAW2WIRE_MACRO_MENU_str, 56)
+void MSG_RAW2WIRE_MODE_HEADER_str(void);
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_MODE_HEADER_str, 16)
+void MSG_RAW3WIRE_MODE_HEADER_str(void);
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW3WIRE_MODE_HEADER_str, 20)
+void MSG_RAW_BRG_VALUE_INPUT_str(void);
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(MSG_RAW_BRG_VALUE_INPUT_str, 23)
+void MSG_RAW_MODE_IDENTIFIER_str(void);
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(MSG_RAW_MODE_IDENTIFIER_str, 4)
+void MSG_RESET_MESSAGE_str(void);
+#define MSG_RESET_MESSAGE bp_message_write_line(MSG_RESET_MESSAGE_str, 5)
+void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(MSG_SOFTWARE_MODE_SPEED_PROMPT_str, 59)
+void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(MSG_SPI_COULD_NOT_KEEP_UP_str, 16)
+void MSG_SPI_CS_DISABLED_str(void);
+#define MSG_SPI_CS_DISABLED bp_message_write_line(MSG_SPI_CS_DISABLED_str, 11)
+void MSG_SPI_CS_ENABLED_str(void);
+#define MSG_SPI_CS_ENABLED bp_message_write_line(MSG_SPI_CS_ENABLED_str, 10)
+void MSG_SPI_CS_MODE_PROMPT_str(void);
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(MSG_SPI_CS_MODE_PROMPT_str, 29)
+void MSG_SPI_MODE_IDENTIFIER_str(void);
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(MSG_SPI_MODE_IDENTIFIER_str, 4)
+void MSG_SPI_PINS_STATE_str(void);
+#define MSG_SPI_PINS_STATE bp_message_write_line(MSG_SPI_PINS_STATE_str, 16)
+void MSG_UART_MODE_IDENTIFIER_str(void);
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(MSG_UART_MODE_IDENTIFIER_str, 4)
+void MSG_UART_NORMAL_TO_EXIT_str(void);
+#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(MSG_UART_NORMAL_TO_EXIT_str, 14)
+void MSG_UART_PINS_STATE_str(void);
+#define MSG_UART_PINS_STATE bp_message_write_line(MSG_UART_PINS_STATE_str, 11)
+void MSG_UNKNOWN_MACRO_ERROR_str(void);
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(MSG_UNKNOWN_MACRO_ERROR_str, 36)
+void MSG_USING_ONBOARD_I2C_EEPROM_str(void);
+#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(MSG_USING_ONBOARD_I2C_EEPROM_str, 39)
+void MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str(void);
+#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str, 41)
+void MSG_VPU_3V3_MARKER_str(void);
+#define MSG_VPU_3V3_MARKER bp_message_write_buffer(MSG_VPU_3V3_MARKER_str, 9)
+void MSG_VPU_5V_MARKER_str(void);
+#define MSG_VPU_5V_MARKER bp_message_write_buffer(MSG_VPU_5V_MARKER_str, 8)
+void MSG_VREG_TOO_LOW_str(void);
+#define MSG_VREG_TOO_LOW bp_message_write_line(MSG_VREG_TOO_LOW_str, 31)
+void MSG_XSV1_MODE_IDENTIFIER_str(void);
+#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(MSG_XSV1_MODE_IDENTIFIER_str, 4)
 
 #endif /* BP_MESSAGES_V4_H */

--- a/Firmware/messages_v4.s
+++ b/Firmware/messages_v4.s
@@ -1,901 +1,1794 @@
-.global _bp_messages
-
-_bp_messages:
-
 	; BPMSG1001
+	.section .text.BPMSG1001, code
+	.global _BPMSG1001_str
+_BPMSG1001_str:
 	.pascii " *next clock (^) will use this value"
 
 	; BPMSG1004
+	.section .text.BPMSG1004, code
+	.global _BPMSG1004_str
+_BPMSG1004_str:
 	.pascii "No device, try (ALARM) SEARCH macro first"
 
 	; BPMSG1005
+	.section .text.BPMSG1005, code
+	.global _BPMSG1005_str
+_BPMSG1005_str:
 	.pascii "ADDRESS MACRO "
 
 	; BPMSG1006
+	.section .text.BPMSG1006, code
+	.global _BPMSG1006_str
+_BPMSG1006_str:
 	.pascii " 0.Macro menu"
 
 	; BPMSG1007
+	.section .text.BPMSG1007, code
+	.global _BPMSG1007_str
+_BPMSG1007_str:
 	.pascii "Macro     1WIRE address"
 
 	; BPMSG1008
+	.section .text.BPMSG1008, code
+	.global _BPMSG1008_str
+_BPMSG1008_str:
 	.pascii "\r\n   *"
 
 	; BPMSG1009
+	.section .text.BPMSG1009, code
+	.global _BPMSG1009_str
+_BPMSG1009_str:
 	.pascii "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
 
 	; BPMSG1010
+	.section .text.BPMSG1010, code
+	.global _BPMSG1010_str
+_BPMSG1010_str:
 	.pascii "ALARM SEARCH (0xEC)"
 
 	; BPMSG1011
+	.section .text.BPMSG1011, code
+	.global _BPMSG1011_str
+_BPMSG1011_str:
 	.pascii "SEARCH (0xF0)"
 
 	; BPMSG1012
+	.section .text.BPMSG1012, code
+	.global _BPMSG1012_str
+_BPMSG1012_str:
 	.pascii "Device IDs are available by MACRO, see (0)."
 
 	; BPMSG1013
+	.section .text.BPMSG1013, code
+	.global _BPMSG1013_str
+_BPMSG1013_str:
 	.pascii "READ ROM (0x33): "
 
 	; BPMSG1014
+	.section .text.BPMSG1014, code
+	.global _BPMSG1014_str
+_BPMSG1014_str:
 	.pascii "MATCH ROM (0x55)"
 
 	; BPMSG1015
+	.section .text.BPMSG1015, code
+	.global _BPMSG1015_str
+_BPMSG1015_str:
 	.pascii "SKIP ROM (0xCC)"
 
 	; BPMSG1017
+	.section .text.BPMSG1017, code
+	.global _BPMSG1017_str
+_BPMSG1017_str:
 	.pascii "BUS RESET "
 
 	; BPMSG1019
+	.section .text.BPMSG1019, code
+	.global _BPMSG1019_str
+_BPMSG1019_str:
 	.pascii "Warning: "
 
 	; BPMSG1020
+	.section .text.BPMSG1020, code
+	.global _BPMSG1020_str
+_BPMSG1020_str:
 	.pascii "*Short or no pull-up "
 
 	; BPMSG1021
+	.section .text.BPMSG1021, code
+	.global _BPMSG1021_str
+_BPMSG1021_str:
 	.pascii "*No device detected "
 
 	; BPMSG1022
+	.section .text.BPMSG1022, code
+	.global _BPMSG1022_str
+_BPMSG1022_str:
 	.pascii "DS18S20 High Pres Dig Therm"
 
 	; BPMSG1023
+	.section .text.BPMSG1023, code
+	.global _BPMSG1023_str
+_BPMSG1023_str:
 	.pascii "DS18B20 Prog Res Dig Therm"
 
 	; BPMSG1024
+	.section .text.BPMSG1024, code
+	.global _BPMSG1024_str
+_BPMSG1024_str:
 	.pascii "DS1822 Econ Dig Therm"
 
 	; BPMSG1025
+	.section .text.BPMSG1025, code
+	.global _BPMSG1025_str
+_BPMSG1025_str:
 	.pascii "DS2404 Econram time Chip"
 
 	; BPMSG1026
+	.section .text.BPMSG1026, code
+	.global _BPMSG1026_str
+_BPMSG1026_str:
 	.pascii "DS2431 1K EEPROM"
 
 	; BPMSG1027
+	.section .text.BPMSG1027, code
+	.global _BPMSG1027_str
+_BPMSG1027_str:
 	.pascii "Unknown device"
 
 	; BPMSG1028
+	.section .text.BPMSG1028, code
+	.global _BPMSG1028_str
+_BPMSG1028_str:
 	.pascii "PWM disabled"
 
 	; BPMSG1029
+	.section .text.BPMSG1029, code
+	.global _BPMSG1029_str
+_BPMSG1029_str:
 	.pascii "1KHz-4,000KHz PWM"
 
 	; BPMSG1030
+	.section .text.BPMSG1030, code
+	.global _BPMSG1030_str
+_BPMSG1030_str:
 	.pascii "Frequency in KHz "
 
 	; BPMSG1033
+	.section .text.BPMSG1033, code
+	.global _BPMSG1033_str
+_BPMSG1033_str:
 	.pascii "Duty cycle in % "
 
 	; BPMSG1034
+	.section .text.BPMSG1034, code
+	.global _BPMSG1034_str
+_BPMSG1034_str:
 	.pascii "PWM active"
 
 	; BPMSG1037
+	.section .text.BPMSG1037, code
+	.global _BPMSG1037_str
+_BPMSG1037_str:
 	.pascii "ERROR: PWM active, g to disable"
 
 	; BPMSG1038
+	.section .text.BPMSG1038, code
+	.global _BPMSG1038_str
+_BPMSG1038_str:
 	.pascii "AUX Frequency: "
 
 	; BPMSG1039
+	.section .text.BPMSG1039, code
+	.global _BPMSG1039_str
+_BPMSG1039_str:
 	.pascii "AUX INPUT/HI-Z"
 
 	; BPMSG1040
+	.section .text.BPMSG1040, code
+	.global _BPMSG1040_str
+_BPMSG1040_str:
 	.pascii "AUX HIGH"
 
 	; BPMSG1041
+	.section .text.BPMSG1041, code
+	.global _BPMSG1041_str
+_BPMSG1041_str:
 	.pascii "AUX LOW"
 
 	; BPMSG1042
+	.section .text.BPMSG1042, code
+	.global _BPMSG1042_str
+_BPMSG1042_str:
 	.pascii "VOLTMETER MODE"
 
 	; BPMSG1044
+	.section .text.BPMSG1044, code
+	.global _BPMSG1044_str
+_BPMSG1044_str:
 	.pascii "VOLTAGE PROBE: "
 
 	; BPMSG1045
+	.section .text.BPMSG1045, code
+	.global _BPMSG1045_str
+_BPMSG1045_str:
 	.pascii "V"
 
 	; BPMSG1047
+	.section .text.BPMSG1047, code
+	.global _BPMSG1047_str
+_BPMSG1047_str:
 	.pascii "Error("
 
 	; BPMSG1048
+	.section .text.BPMSG1048, code
+	.global _BPMSG1048_str
+_BPMSG1048_str:
 	.pascii ") @line:"
 
 	; BPMSG1049
+	.section .text.BPMSG1049, code
+	.global _BPMSG1049_str
+_BPMSG1049_str:
 	.pascii " @pgmspace:"
 
 	; BPMSG1050
+	.section .text.BPMSG1050, code
+	.global _BPMSG1050_str
+_BPMSG1050_str:
 	.pascii " bytes."
 
 	; BPMSG1051
+	.section .text.BPMSG1051, code
+	.global _BPMSG1051_str
+_BPMSG1051_str:
 	.pascii "Too long!"
 
 	; BPMSG1052
+	.section .text.BPMSG1052, code
+	.global _BPMSG1052_str
+_BPMSG1052_str:
 	.pascii "Syntax error"
 
 	; BPMSG1053
+	.section .text.BPMSG1053, code
+	.global _BPMSG1053_str
+_BPMSG1053_str:
 	.pascii "No EEPROM"
 
 	; BPMSG1054
+	.section .text.BPMSG1054, code
+	.global _BPMSG1054_str
+_BPMSG1054_str:
 	.pascii "Erasing"
 
 	; BPMSG1055
+	.section .text.BPMSG1055, code
+	.global _BPMSG1055_str
+_BPMSG1055_str:
 	.pascii "done"
 
 	; BPMSG1056
+	.section .text.BPMSG1056, code
+	.global _BPMSG1056_str
+_BPMSG1056_str:
 	.pascii "Saving to slot "
 
 	; BPMSG1057
+	.section .text.BPMSG1057, code
+	.global _BPMSG1057_str
+_BPMSG1057_str:
 	.pascii "Invalid slot"
 
 	; BPMSG1058
+	.section .text.BPMSG1058, code
+	.global _BPMSG1058_str
+_BPMSG1058_str:
 	.pascii "Loading from slot "
 
 	; BPMSG1059
+	.section .text.BPMSG1059, code
+	.global _BPMSG1059_str
+_BPMSG1059_str:
 	.pascii "ERROR: command has no effect here"
 
 	; BPMSG1064
+	.section .text.BPMSG1064, code
+	.global _BPMSG1064_str
+_BPMSG1064_str:
 	.pascii "I2C mode:\r\n 1. Software\r\n 2. Hardware"
 
 	; BPMSG1067
+	.section .text.BPMSG1067, code
+	.global _BPMSG1067_str
+_BPMSG1067_str:
 	.pascii "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
 
 	; BPMSG1068
+	.section .text.BPMSG1068, code
+	.global _BPMSG1068_str
+_BPMSG1068_str:
 	.pascii "I2C (mod spd)=( "
 
 	; BPMSG1069
+	.section .text.BPMSG1069, code
+	.global _BPMSG1069_str
+_BPMSG1069_str:
 	.pascii " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer\r\n 3.Connect to on-board EEPROM\r\n 4.Enable Writing the on-board EEPROM"
 
 	; BPMSG1070
+	.section .text.BPMSG1070, code
+	.global _BPMSG1070_str
+_BPMSG1070_str:
 	.pascii "Searching I2C address space. Found devices at:"
 
 	; BPMSG1071
+	.section .text.BPMSG1071, code
+	.global _BPMSG1071_str
+_BPMSG1071_str:
 	.pascii "Sniffer"
 
 	; BPMSG1072
+	.section .text.BPMSG1072, code
+	.global _BPMSG1072_str
+_BPMSG1072_str:
 	.pascii "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
 
 	; BPMSG1073
+	.section .text.BPMSG1073, code
+	.global _BPMSG1073_str
+_BPMSG1073_str:
 	.pascii "Delay?"
 
 	; BPMSG1074
+	.section .text.BPMSG1074, code
+	.global _BPMSG1074_str
+_BPMSG1074_str:
 	.pascii "PIC(mod dly)=("
 
 	; BPMSG1075
+	.section .text.BPMSG1075, code
+	.global _BPMSG1075_str
+_BPMSG1075_str:
 	.pascii "CMD"
 
 	; BPMSG1076
+	.section .text.BPMSG1076, code
+	.global _BPMSG1076_str
+_BPMSG1076_str:
 	.pascii "DTA"
 
 	; BPMSG1077
+	.section .text.BPMSG1077, code
+	.global _BPMSG1077_str
+_BPMSG1077_str:
 	.pascii "no read"
 
 	; BPMSG1078
+	.section .text.BPMSG1078, code
+	.global _BPMSG1078_str
+_BPMSG1078_str:
 	.pascii "unknown mode"
 
 	; BPMSG1079
+	.section .text.BPMSG1079, code
+	.global _BPMSG1079_str
+_BPMSG1079_str:
 	.pascii "(1) get devID"
 
 	; BPMSG1080
+	.section .text.BPMSG1080, code
+	.global _BPMSG1080_str
+_BPMSG1080_str:
 	.pascii "DevID = "
 
 	; BPMSG1081
+	.section .text.BPMSG1081, code
+	.global _BPMSG1081_str
+_BPMSG1081_str:
 	.pascii " Rev = "
 
 	; BPMSG1082
+	.section .text.BPMSG1082, code
+	.global _BPMSG1082_str
+_BPMSG1082_str:
 	.pascii "Not implemented (yet)"
 
 	; BPMSG1083
+	.section .text.BPMSG1083, code
+	.global _BPMSG1083_str
+_BPMSG1083_str:
 	.pascii "Please exit PIC programming mode"
 
 	; BPMSG1084
+	.section .text.BPMSG1084, code
+	.global _BPMSG1084_str
+_BPMSG1084_str:
 	.pascii "(BASIC)"
 
 	; BPMSG1085
+	.section .text.BPMSG1085, code
+	.global _BPMSG1085_str
+_BPMSG1085_str:
 	.pascii "Ready"
 
 	; BPMSG1086
+	.section .text.BPMSG1086, code
+	.global _BPMSG1086_str
+_BPMSG1086_str:
 	.pascii "a/A/@ controls AUX pin"
 
 	; BPMSG1087
+	.section .text.BPMSG1087, code
+	.global _BPMSG1087_str
+_BPMSG1087_str:
 	.pascii "a/A/@ controls CS pin"
 
 	; BPMSG1088
+	.section .text.BPMSG1088, code
+	.global _BPMSG1088_str
+_BPMSG1088_str:
 	.pascii "Command not used in this mode"
 
 	; BPMSG1089
+	.section .text.BPMSG1089, code
+	.global _BPMSG1089_str
+_BPMSG1089_str:
 	.pascii "Pull-up resistors OFF"
 
 	; BPMSG1091
+	.section .text.BPMSG1091, code
+	.global _BPMSG1091_str
+_BPMSG1091_str:
 	.pascii "Pull-up resistors ON"
 
 	; BPMSG1092
+	.section .text.BPMSG1092, code
+	.global _BPMSG1092_str
+_BPMSG1092_str:
 	.pascii "Self-test in HiZ mode only"
 
 	; BPMSG1093
+	.section .text.BPMSG1093, code
+	.global _BPMSG1093_str
+_BPMSG1093_str:
 	.pascii "RESET"
 
 	; BPMSG1094
+	.section .text.BPMSG1094, code
+	.global _BPMSG1094_str
+_BPMSG1094_str:
 	.pascii "BOOTLOADER"
 
 	; BPMSG1095
+	.section .text.BPMSG1095, code
+	.global _BPMSG1095_str
+_BPMSG1095_str:
 	.pascii "AUX INPUT/HI-Z, READ: "
 
 	; BPMSG1096
+	.section .text.BPMSG1096, code
+	.global _BPMSG1096_str
+_BPMSG1096_str:
 	.pascii "POWER SUPPLIES ON"
 
 	; BPMSG1097
+	.section .text.BPMSG1097, code
+	.global _BPMSG1097_str
+_BPMSG1097_str:
 	.pascii "POWER SUPPLIES OFF"
 
 	; BPMSG1098
+	.section .text.BPMSG1098, code
+	.global _BPMSG1098_str
+_BPMSG1098_str:
 	.pascii "DATA STATE: "
 
 	; BPMSG1099
+	.section .text.BPMSG1099, code
+	.global _BPMSG1099_str
+_BPMSG1099_str:
 	.pascii "DELAY "
 
 	; BPMSG1100
+	.section .text.BPMSG1100, code
+	.global _BPMSG1100_str
+_BPMSG1100_str:
 	.pascii "us"
 
 	; BPMSG1101
+	.section .text.BPMSG1101, code
+	.global _BPMSG1101_str
+_BPMSG1101_str:
 	.pascii "WRITE: "
 
 	; BPMSG1102
+	.section .text.BPMSG1102, code
+	.global _BPMSG1102_str
+_BPMSG1102_str:
 	.pascii "READ: "
 
 	; BPMSG1103
+	.section .text.BPMSG1103, code
+	.global _BPMSG1103_str
+_BPMSG1103_str:
 	.pascii "CLOCK, 1"
 
 	; BPMSG1104
+	.section .text.BPMSG1104, code
+	.global _BPMSG1104_str
+_BPMSG1104_str:
 	.pascii "CLOCK, 0"
 
 	; BPMSG1105
+	.section .text.BPMSG1105, code
+	.global _BPMSG1105_str
+_BPMSG1105_str:
 	.pascii "DATA OUTPUT, 1"
 
 	; BPMSG1106
+	.section .text.BPMSG1106, code
+	.global _BPMSG1106_str
+_BPMSG1106_str:
 	.pascii "DATA OUTPUT, 0"
 
 	; BPMSG1107
+	.section .text.BPMSG1107, code
+	.global _BPMSG1107_str
+_BPMSG1107_str:
 	.pascii " *pin is now HiZ"
 
 	; BPMSG1108
+	.section .text.BPMSG1108, code
+	.global _BPMSG1108_str
+_BPMSG1108_str:
 	.pascii "CLOCK TICKS: "
 
 	; BPMSG1109
+	.section .text.BPMSG1109, code
+	.global _BPMSG1109_str
+_BPMSG1109_str:
 	.pascii "READ BIT: "
 
 	; BPMSG1110
+	.section .text.BPMSG1110, code
+	.global _BPMSG1110_str
+_BPMSG1110_str:
 	.pascii "Syntax error at char "
 
 	; BPMSG1111
+	.section .text.BPMSG1111, code
+	.global _BPMSG1111_str
+_BPMSG1111_str:
 	.pascii "x. exit(without change)"
 
 	; BPMSG1112
+	.section .text.BPMSG1112, code
+	.global _BPMSG1112_str
+_BPMSG1112_str:
 	.pascii "no mode change"
 
 	; BPMSG1114
+	.section .text.BPMSG1114, code
+	.global _BPMSG1114_str
+_BPMSG1114_str:
 	.pascii "Nonexistent protocol!"
 
 	; BPMSG1115
+	.section .text.BPMSG1115, code
+	.global _BPMSG1115_str
+_BPMSG1115_str:
 	.pascii "x. exit"
 
 	; BPMSG1117
+	.section .text.BPMSG1117, code
+	.global _BPMSG1117_str
+_BPMSG1117_str:
 	.pascii "DEVID:"
 
 	; BPMSG1118
+	.section .text.BPMSG1118, code
+	.global _BPMSG1118_str
+_BPMSG1118_str:
 	.pascii "http://dangerousprototypes.com"
 
 	; BPMSG1119
+	.section .text.BPMSG1119, code
+	.global _BPMSG1119_str
+_BPMSG1119_str:
 	.pascii "*----------*"
 
 	; BPMSG1120
+	.section .text.BPMSG1120, code
+	.global _BPMSG1120_str
+_BPMSG1120_str:
 	.pascii "Open drain outputs (H=Hi-Z, L=GND)"
 
 	; BPMSG1121
+	.section .text.BPMSG1121, code
+	.global _BPMSG1121_str
+_BPMSG1121_str:
 	.pascii "Normal outputs (H=3.3v, L=GND)"
 
 	; BPMSG1123
+	.section .text.BPMSG1123, code
+	.global _BPMSG1123_str
+_BPMSG1123_str:
 	.pascii "MSB set: MOST sig bit first"
 
 	; BPMSG1124
+	.section .text.BPMSG1124, code
+	.global _BPMSG1124_str
+_BPMSG1124_str:
 	.pascii "LSB set: LEAST sig bit first"
 
 	; BPMSG1127
+	.section .text.BPMSG1127, code
+	.global _BPMSG1127_str
+_BPMSG1127_str:
 	.pascii " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
 
 	; BPMSG1128
+	.section .text.BPMSG1128, code
+	.global _BPMSG1128_str
+_BPMSG1128_str:
 	.pascii "Display format set"
 
 	; BPMSG1133
+	.section .text.BPMSG1133, code
+	.global _BPMSG1133_str
+_BPMSG1133_str:
 	.pascii "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. Input Custom BAUD\r\n11. Auto-Baud Detection (Activity Required)"
 
 	; BPMSG1134
+	.section .text.BPMSG1134, code
+	.global _BPMSG1134_str
+_BPMSG1134_str:
 	.pascii "Adjust your terminal"
 
 	; BPMSG1135
+	.section .text.BPMSG1135, code
+	.global _BPMSG1135_str
+_BPMSG1135_str:
 	.pascii "Are you sure? "
 
 	; BPMSG1136
+	.section .text.BPMSG1136, code
+	.global _BPMSG1136_str
+_BPMSG1136_str:
 	.pascii "CFG1:"
 
 	; BPMSG1137
+	.section .text.BPMSG1137, code
+	.global _BPMSG1137_str
+_BPMSG1137_str:
 	.pascii " CFG2:"
 
 	; BPMSG1163
+	.section .text.BPMSG1163, code
+	.global _BPMSG1163_str
+_BPMSG1163_str:
 	.pascii "Disconnect any devices\r\nConnect (ADC to +3.3V)"
 
 	; BPMSG1164
+	.section .text.BPMSG1164, code
+	.global _BPMSG1164_str
+_BPMSG1164_str:
 	.pascii "Ctrl"
 
 	; BPMSG1165
+	.section .text.BPMSG1165, code
+	.global _BPMSG1165_str
+_BPMSG1165_str:
 	.pascii "AUX"
 
 	; BPMSG1166
+	.section .text.BPMSG1166, code
+	.global _BPMSG1166_str
+_BPMSG1166_str:
 	.pascii "MODE LED"
 
 	; BPMSG1167
+	.section .text.BPMSG1167, code
+	.global _BPMSG1167_str
+_BPMSG1167_str:
 	.pascii "PULLUP H"
 
 	; BPMSG1168
+	.section .text.BPMSG1168, code
+	.global _BPMSG1168_str
+_BPMSG1168_str:
 	.pascii "PULLUP L"
 
 	; BPMSG1169
+	.section .text.BPMSG1169, code
+	.global _BPMSG1169_str
+_BPMSG1169_str:
 	.pascii "VREG"
 
 	; BPMSG1170
+	.section .text.BPMSG1170, code
+	.global _BPMSG1170_str
+_BPMSG1170_str:
 	.pascii "ADC and supply"
 
 	; BPMSG1171
+	.section .text.BPMSG1171, code
+	.global _BPMSG1171_str
+_BPMSG1171_str:
 	.pascii "5V"
 
 	; BPMSG1172
+	.section .text.BPMSG1172, code
+	.global _BPMSG1172_str
+_BPMSG1172_str:
 	.pascii "VPU"
 
 	; BPMSG1173
+	.section .text.BPMSG1173, code
+	.global _BPMSG1173_str
+_BPMSG1173_str:
 	.pascii "3.3V"
 
 	; BPMSG1174
+	.section .text.BPMSG1174, code
+	.global _BPMSG1174_str
+_BPMSG1174_str:
 	.pascii "ADC"
 
 	; BPMSG1175
+	.section .text.BPMSG1175, code
+	.global _BPMSG1175_str
+_BPMSG1175_str:
 	.pascii "Bus high"
 
 	; BPMSG1176
+	.section .text.BPMSG1176, code
+	.global _BPMSG1176_str
+_BPMSG1176_str:
 	.pascii "Bus Hi-Z 0"
 
 	; BPMSG1177
+	.section .text.BPMSG1177, code
+	.global _BPMSG1177_str
+_BPMSG1177_str:
 	.pascii "Bus Hi-Z 1"
 
 	; BPMSG1178
+	.section .text.BPMSG1178, code
+	.global _BPMSG1178_str
+_BPMSG1178_str:
 	.pascii "MODE, VREG, and USB LEDs should be on!"
 
 	; BPMSG1179
+	.section .text.BPMSG1179, code
+	.global _BPMSG1179_str
+_BPMSG1179_str:
 	.pascii "Found "
 
 	; BPMSG1180
+	.section .text.BPMSG1180, code
+	.global _BPMSG1180_str
+_BPMSG1180_str:
 	.pascii " errors."
 
 	; BPMSG1181
+	.section .text.BPMSG1181, code
+	.global _BPMSG1181_str
+_BPMSG1181_str:
 	.pascii "MOSI"
 
 	; BPMSG1182
+	.section .text.BPMSG1182, code
+	.global _BPMSG1182_str
+_BPMSG1182_str:
 	.pascii "CLK"
 
 	; BPMSG1183
+	.section .text.BPMSG1183, code
+	.global _BPMSG1183_str
+_BPMSG1183_str:
 	.pascii "MISO"
 
 	; BPMSG1184
+	.section .text.BPMSG1184, code
+	.global _BPMSG1184_str
+_BPMSG1184_str:
 	.pascii "CS"
 
 	; BPMSG1185
+	.section .text.BPMSG1185, code
+	.global _BPMSG1185_str
+_BPMSG1185_str:
 	.pascii " OK"
 
 	; BPMSG1186
+	.section .text.BPMSG1186, code
+	.global _BPMSG1186_str
+_BPMSG1186_str:
 	.pascii " FAIL"
 
 	; BPMSG1187
+	.section .text.BPMSG1187, code
+	.global _BPMSG1187_str
+_BPMSG1187_str:
 	.pascii "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
 
 	; BPMSG1188
+	.section .text.BPMSG1188, code
+	.global _BPMSG1188_str
+_BPMSG1188_str:
 	.pascii "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
 
 	; BPMSG1189
+	.section .text.BPMSG1189, code
+	.global _BPMSG1189_str
+_BPMSG1189_str:
 	.pascii "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
 
 	; BPMSG1190
+	.section .text.BPMSG1190, code
+	.global _BPMSG1190_str
+_BPMSG1190_str:
 	.pascii "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
 
 	; BPMSG1191
+	.section .text.BPMSG1191, code
+	.global _BPMSG1191_str
+_BPMSG1191_str:
 	.pascii "SPI (spd ckp ske smp csl hiz)=( "
 
 	; BPMSG1192
+	.section .text.BPMSG1192, code
+	.global _BPMSG1192_str
+_BPMSG1192_str:
 	.pascii " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic"
 
 	; BPMSG1194
+	.section .text.BPMSG1194, code
+	.global _BPMSG1194_str
+_BPMSG1194_str:
 	.pascii "-p "
 
 	; BPMSG1195
+	.section .text.BPMSG1195, code
+	.global _BPMSG1195_str
+_BPMSG1195_str:
 	.pascii "-f "
 
 	; BPMSG1196
+	.section .text.BPMSG1196, code
+	.global _BPMSG1196_str
+_BPMSG1196_str:
 	.pascii "*Bytes dropped*"
 
 	; BPMSG1197
+	.section .text.BPMSG1197, code
+	.global _BPMSG1197_str
+_BPMSG1197_str:
 	.pascii "FAILED, NO DATA"
 
 	; BPMSG1199
+	.section .text.BPMSG1199, code
+	.global _BPMSG1199_str
+_BPMSG1199_str:
 	.pascii "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
 
 	; BPMSG1200
+	.section .text.BPMSG1200, code
+	.global _BPMSG1200_str
+_BPMSG1200_str:
 	.pascii "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
 
 	; BPMSG1201
+	.section .text.BPMSG1201, code
+	.global _BPMSG1201_str
+_BPMSG1201_str:
 	.pascii "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
 
 	; BPMSG1202
+	.section .text.BPMSG1202, code
+	.global _BPMSG1202_str
+_BPMSG1202_str:
 	.pascii "UART (spd brg dbp sb rxp hiz)=( "
 
 	; BPMSG1203
+	.section .text.BPMSG1203, code
+	.global _BPMSG1203_str
+_BPMSG1203_str:
 	.pascii " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection (Activity Needed)"
 
 	; BPMSG1204
+	.section .text.BPMSG1204, code
+	.global _BPMSG1204_str
+_BPMSG1204_str:
 	.pascii "UART bridge"
 
 	; BPMSG1206
+	.section .text.BPMSG1206, code
+	.global _BPMSG1206_str
+_BPMSG1206_str:
 	.pascii "Raw UART input"
 
 	; BPMSG1207
+	.section .text.BPMSG1207, code
+	.global _BPMSG1207_str
+_BPMSG1207_str:
 	.pascii "UART LIVE DISPLAY, } TO STOP"
 
 	; BPMSG1208
+	.section .text.BPMSG1208, code
+	.global _BPMSG1208_str
+_BPMSG1208_str:
 	.pascii "LIVE DISPLAY STOPPED"
 
 	; BPMSG1209
+	.section .text.BPMSG1209, code
+	.global _BPMSG1209_str
+_BPMSG1209_str:
 	.pascii "WARNING: pins not open drain (HiZ)"
 
 	; BPMSG1210
+	.section .text.BPMSG1210, code
+	.global _BPMSG1210_str
+_BPMSG1210_str:
 	.pascii " REVID:"
 
 	; BPMSG1211
+	.section .text.BPMSG1211, code
+	.global _BPMSG1211_str
+_BPMSG1211_str:
 	.pascii "\r\nInvalid choice, try again"
 
 	; BPMSG1212
+	.section .text.BPMSG1212, code
+	.global _BPMSG1212_str
+_BPMSG1212_str:
 	.pascii "ms"
 
 	; BPMSG1213
+	.section .text.BPMSG1213, code
+	.global _BPMSG1213_str
+_BPMSG1213_str:
 	.pascii "RS LOW, COMMAND MODE"
 
 	; BPMSG1214
+	.section .text.BPMSG1214, code
+	.global _BPMSG1214_str
+_BPMSG1214_str:
 	.pascii "RS HIGH, DATA MODE"
 
 	; BPMSG1216
+	.section .text.BPMSG1216, code
+	.global _BPMSG1216_str
+_BPMSG1216_str:
 	.pascii "This mode requires an adapter"
 
 	; BPMSG1219
+	.section .text.BPMSG1219, code
+	.global _BPMSG1219_str
+_BPMSG1219_str:
 	.pascii " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
 
 	; BPMSG1220
+	.section .text.BPMSG1220, code
+	.global _BPMSG1220_str
+_BPMSG1220_str:
 	.pascii "Display lines:\r\n 1. 1 \r\n 2. Multiple"
 
 	; BPMSG1221
+	.section .text.BPMSG1221, code
+	.global _BPMSG1221_str
+_BPMSG1221_str:
 	.pascii "INIT"
 
 	; BPMSG1222
+	.section .text.BPMSG1222, code
+	.global _BPMSG1222_str
+_BPMSG1222_str:
 	.pascii "CLEAR"
 
 	; BPMSG1223
+	.section .text.BPMSG1223, code
+	.global _BPMSG1223_str
+_BPMSG1223_str:
 	.pascii "CURSOR SET"
 
 	; BPMSG1226
+	.section .text.BPMSG1226, code
+	.global _BPMSG1226_str
+_BPMSG1226_str:
 	.pascii "Pinstates:"
 
 	; BPMSG1228
+	.section .text.BPMSG1228, code
+	.global _BPMSG1228_str
+_BPMSG1228_str:
 	.pascii "P\tP\tP\tI\tI\t"
 
 	; BPMSG1234
+	.section .text.BPMSG1234, code
+	.global _BPMSG1234_str
+_BPMSG1234_str:
 	.pascii "GND\t"
 
 	; BPMSG1237
+	.section .text.BPMSG1237, code
+	.global _BPMSG1237_str
+_BPMSG1237_str:
 	.pascii " TIMEOUT"
 
 	; BPMSG1238
+	.section .text.BPMSG1238, code
+	.global _BPMSG1238_str
+_BPMSG1238_str:
 	.pascii " 0. Macro menu\r\n 1. Live input monitor"
 
 	; BPMSG1239
+	.section .text.BPMSG1239, code
+	.global _BPMSG1239_str
+_BPMSG1239_str:
 	.pascii "Input monitor, any key exits"
 
 	; BPMSG1240
+	.section .text.BPMSG1240, code
+	.global _BPMSG1240_str
+_BPMSG1240_str:
 	.pascii " *startbit error"
 
 	; BPMSG1241
+	.section .text.BPMSG1241, code
+	.global _BPMSG1241_str
+_BPMSG1241_str:
 	.pascii " *parity error"
 
 	; BPMSG1242
+	.section .text.BPMSG1242, code
+	.global _BPMSG1242_str
+_BPMSG1242_str:
 	.pascii " *stopbit error"
 
 	; BPMSG1243
+	.section .text.BPMSG1243, code
+	.global _BPMSG1243_str
+_BPMSG1243_str:
 	.pascii " NONE"
 
 	; BPMSG1244
+	.section .text.BPMSG1244, code
+	.global _BPMSG1244_str
+_BPMSG1244_str:
 	.pascii " UNKNOWN ERROR"
 
 	; BPMSG1245
+	.section .text.BPMSG1245, code
+	.global _BPMSG1245_str
+_BPMSG1245_str:
 	.pascii " autorange "
 
 	; BPMSG1248
+	.section .text.BPMSG1248, code
+	.global _BPMSG1248_str
+_BPMSG1248_str:
 	.pascii "Input a custom BAUD rate:"
 
 	; BPMSG1250
+	.section .text.BPMSG1250, code
+	.global _BPMSG1250_str
+_BPMSG1250_str:
 	.pascii "Any key to exit"
 
 	; BPMSG1251
+	.section .text.BPMSG1251, code
+	.global _BPMSG1251_str
+_BPMSG1251_str:
 	.pascii "Space to continue"
 
 	; BPMSG1252
+	.section .text.BPMSG1252, code
+	.global _BPMSG1252_str
+_BPMSG1252_str:
 	.pascii "Number of bits read/write: "
 
 	; BPMSG1254
+	.section .text.BPMSG1254, code
+	.global _BPMSG1254_str
+_BPMSG1254_str:
 	.pascii "Position in degrees"
 
 	; BPMSG1255
+	.section .text.BPMSG1255, code
+	.global _BPMSG1255_str
+_BPMSG1255_str:
 	.pascii "Servo active"
 
 	; BPMSG1256
+	.section .text.BPMSG1256, code
+	.global _BPMSG1256_str
+_BPMSG1256_str:
 	.pascii "#12    \t#11    \t#10    \t#09   \t#08   \t#07   \t#06   \t#05   \t#04   \t#03   \t#02   \t#01   "
 
 	; BPMSG1257
+	.section .text.BPMSG1257, code
+	.global _BPMSG1257_str
+_BPMSG1257_str:
 	.pascii "GND\t5.0V\t3.3V\tVPU\tADC\tAUX2\tAUX1\tAUX\t"
 
 	; BPMSG1259
+	.section .text.BPMSG1259, code
+	.global _BPMSG1259_str
+_BPMSG1259_str:
 	.pascii "-\t-\t-\tOWD"
 
 	; BPMSG1262
+	.section .text.BPMSG1262, code
+	.global _BPMSG1262_str
+_BPMSG1262_str:
 	.pascii "-\t-\tPGC\tPGD"
 
 	; BPMSG1263
+	.section .text.BPMSG1263, code
+	.global _BPMSG1263_str
+_BPMSG1263_str:
 	.pascii "a/A/@ controls AUX1 pin"
 
 	; BPMSG1264
+	.section .text.BPMSG1264, code
+	.global _BPMSG1264_str
+_BPMSG1264_str:
 	.pascii "a/A/@ controls AUX2 pin"
 
 	; BPMSG1265
+	.section .text.BPMSG1265, code
+	.global _BPMSG1265_str
+_BPMSG1265_str:
 	.pascii "EEPROM"
 
 	; BPMSG1266
+	.section .text.BPMSG1266, code
+	.global _BPMSG1266_str
+_BPMSG1266_str:
 	.pascii "SCL"
 
 	; BPMSG1267
+	.section .text.BPMSG1267, code
+	.global _BPMSG1267_str
+_BPMSG1267_str:
 	.pascii "SDA"
 
 	; BPMSG1268
+	.section .text.BPMSG1268, code
+	.global _BPMSG1268_str
+_BPMSG1268_str:
 	.pascii "WP"
 
 	; BPMSG1269
+	.section .text.BPMSG1269, code
+	.global _BPMSG1269_str
+_BPMSG1269_str:
 	.pascii "READ&WRITE"
 
 	; BPMSG1270
+	.section .text.BPMSG1270, code
+	.global _BPMSG1270_str
+_BPMSG1270_str:
 	.pascii "Vusb"
 
 	; BPMSG1271
+	.section .text.BPMSG1271, code
+	.global _BPMSG1271_str
+_BPMSG1271_str:
 	.pascii "Select Vpu (Pullup) Source:\r\n 1) External (or None)\r\n 2) Onboard 3.3v\r\n 3) Onboard 5.0v"
 
 	; BPMSG1272
+	.section .text.BPMSG1272, code
+	.global _BPMSG1272_str
+_BPMSG1272_str:
 	.pascii " on-board pullup voltage "
 
 	; BPMSG1273
+	.section .text.BPMSG1273, code
+	.global _BPMSG1273_str
+_BPMSG1273_str:
 	.pascii "enabled"
 
 	; BPMSG1274
+	.section .text.BPMSG1274, code
+	.global _BPMSG1274_str
+_BPMSG1274_str:
 	.pascii "disabled"
 
 	; BPMSG1280
+	.section .text.BPMSG1280, code
+	.global _BPMSG1280_str
+_BPMSG1280_str:
 	.pascii "Waiting activity..."
 
 	; BPMSG1281
+	.section .text.BPMSG1281, code
+	.global _BPMSG1281_str
+_BPMSG1281_str:
 	.pascii "** Early Exit!"
 
 	; BPMSG1282
+	.section .text.BPMSG1282, code
+	.global _BPMSG1282_str
+_BPMSG1282_str:
 	.pascii "** Baud>16m: The BP cannot measure above 16000000, Done."
 
 	; BPMSG1283
+	.section .text.BPMSG1283, code
+	.global _BPMSG1283_str
+_BPMSG1283_str:
 	.pascii "\n\rCalculated: \t"
 
 	; BPMSG1284
+	.section .text.BPMSG1284, code
+	.global _BPMSG1284_str
+_BPMSG1284_str:
 	.pascii "\n\rEstimated:  \t"
 
 	; BPMSG1285
+	.section .text.BPMSG1285, code
+	.global _BPMSG1285_str
+_BPMSG1285_str:
 	.pascii " bps"
 
 	; HLP1000
+	.section .text.HLP1000, code
+	.global _HLP1000_str
+_HLP1000_str:
 	.pascii "General\t\t\t\t\tProtocol interaction"
 
 	; HLP1001
+	.section .text.HLP1001, code
+	.global _HLP1001_str
+_HLP1001_str:
 	.pascii "---------------------------------------------------------------------------"
 
 	; HLP1002
+	.section .text.HLP1002, code
+	.global _HLP1002_str
+_HLP1002_str:
 	.pascii "?\tThis help\t\t\t(0)\tList current macros"
 
 	; HLP1003
+	.section .text.HLP1003, code
+	.global _HLP1003_str
+_HLP1003_str:
 	.pascii "=X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
 
 	; HLP1004
+	.section .text.HLP1004, code
+	.global _HLP1004_str
+_HLP1004_str:
 	.pascii "~\tSelftest\t\t\t[\tStart"
 
 	; HLP1005
+	.section .text.HLP1005, code
+	.global _HLP1005_str
+_HLP1005_str:
 	.pascii "o\tSet output type\t\t\t]\tStop"
 
 	; HLP1006
+	.section .text.HLP1006, code
+	.global _HLP1006_str
+_HLP1006_str:
 	.pascii "$\tJump to bootloader\t\t{\tStart with read"
 
 	; HLP1007
+	.section .text.HLP1007, code
+	.global _HLP1007_str
+_HLP1007_str:
 	.pascii "&/%\tDelay 1 us/ms\t\t\t}\tStop"
 
 	; HLP1008
+	.section .text.HLP1008, code
+	.global _HLP1008_str
+_HLP1008_str:
 	.pascii "a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
 
 	; HLP1009
+	.section .text.HLP1009, code
+	.global _HLP1009_str
+_HLP1009_str:
 	.pascii "b\tSet baudrate\t\t\t123\tSend integer value"
 
 	; HLP1010
+	.section .text.HLP1010, code
+	.global _HLP1010_str
+_HLP1010_str:
 	.pascii "c/C/k/K\tAUX assignment (A0/CS/A1/A2)\t0x123\tSend hex value"
 
 	; HLP1011
+	.section .text.HLP1011, code
+	.global _HLP1011_str
+_HLP1011_str:
 	.pascii "d/D\tMeasure ADC (once/CONT.)\t0b110\tSend binary value"
 
 	; HLP1012
+	.section .text.HLP1012, code
+	.global _HLP1012_str
+_HLP1012_str:
 	.pascii "f\tMeasure frequency\t\tr\tRead"
 
 	; HLP1013
+	.section .text.HLP1013, code
+	.global _HLP1013_str
+_HLP1013_str:
 	.pascii "g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
 
 	; HLP1014
+	.section .text.HLP1014, code
+	.global _HLP1014_str
+_HLP1014_str:
 	.pascii "h\tCommandhistory\t\t\t\\\tCLK lo"
 
 	; HLP1015
+	.section .text.HLP1015, code
+	.global _HLP1015_str
+_HLP1015_str:
 	.pascii "i\tVersioninfo/statusinfo\t\t^\tCLK tick"
 
 	; HLP1016
+	.section .text.HLP1016, code
+	.global _HLP1016_str
+_HLP1016_str:
 	.pascii "l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
 
 	; HLP1017
+	.section .text.HLP1017, code
+	.global _HLP1017_str
+_HLP1017_str:
 	.pascii "m\tChange mode\t\t\t_\tDAT lo"
 
 	; HLP1018
+	.section .text.HLP1018, code
+	.global _HLP1018_str
+_HLP1018_str:
 	.pascii "e\tSet Pullup Method\t\t.\tDAT read"
 
 	; HLP1019
+	.section .text.HLP1019, code
+	.global _HLP1019_str
+_HLP1019_str:
 	.pascii "p/P\tPullup resistors (off/ON)\t!\tBit read"
 
 	; HLP1020
+	.section .text.HLP1020, code
+	.global _HLP1020_str
+_HLP1020_str:
 	.pascii "s\tScript engine\t\t\t:\tRepeat e.g. r:10"
 
 	; HLP1021
+	.section .text.HLP1021, code
+	.global _HLP1021_str
+_HLP1021_str:
 	.pascii "v\tShow volts/states\t\t;\tBits to read/write e.g. 0x55;2"
 
 	; HLP1022
+	.section .text.HLP1022, code
+	.global _HLP1022_str
+_HLP1022_str:
 	.pascii "w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
 
 	; MSG_1WIRE_MODE_IDENTIFIER
+	.section .text.MSG_1WIRE_MODE_IDENTIFIER, code
+	.global _MSG_1WIRE_MODE_IDENTIFIER_str
+_MSG_1WIRE_MODE_IDENTIFIER_str:
 	.pascii "1W01"
 
 	; MSG_1WIRE_SPEED_PROMPT
+	.section .text.MSG_1WIRE_SPEED_PROMPT, code
+	.global _MSG_1WIRE_SPEED_PROMPT_str
+_MSG_1WIRE_SPEED_PROMPT_str:
 	.pascii "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
 
 	; MSG_ACK
+	.section .text.MSG_ACK, code
+	.global _MSG_ACK_str
+_MSG_ACK_str:
 	.pascii "ACK"
 
 	; MSG_BASE_CONVERTER_EQUAL_SIGN
+	.section .text.MSG_BASE_CONVERTER_EQUAL_SIGN, code
+	.global _MSG_BASE_CONVERTER_EQUAL_SIGN_str
+_MSG_BASE_CONVERTER_EQUAL_SIGN_str:
 	.pascii " = "
 
 	; MSG_BAUD_DETECTION_SELECTED
+	.section .text.MSG_BAUD_DETECTION_SELECTED, code
+	.global _MSG_BAUD_DETECTION_SELECTED_str
+_MSG_BAUD_DETECTION_SELECTED_str:
 	.pascii "Baud detection selected.."
 
 	; MSG_BBIO_MODE_IDENTIFIER
+	.section .text.MSG_BBIO_MODE_IDENTIFIER, code
+	.global _MSG_BBIO_MODE_IDENTIFIER_str
+_MSG_BBIO_MODE_IDENTIFIER_str:
 	.pascii "BBIO1"
 
 	; MSG_BINARY_NUMBER_PREFIX
+	.section .text.MSG_BINARY_NUMBER_PREFIX, code
+	.global _MSG_BINARY_NUMBER_PREFIX_str
+_MSG_BINARY_NUMBER_PREFIX_str:
 	.pascii "0b"
 
 	; MSG_CFG0_FIELD
+	.section .text.MSG_CFG0_FIELD, code
+	.global _MSG_CFG0_FIELD_str
+_MSG_CFG0_FIELD_str:
 	.pascii "CFG0: "
 
 	; MSG_CHIP_REVISION_A3
+	.section .text.MSG_CHIP_REVISION_A3, code
+	.global _MSG_CHIP_REVISION_A3_str
+_MSG_CHIP_REVISION_A3_str:
 	.pascii "A3"
 
 	; MSG_CHIP_REVISION_A5
+	.section .text.MSG_CHIP_REVISION_A5, code
+	.global _MSG_CHIP_REVISION_A5_str
+_MSG_CHIP_REVISION_A5_str:
 	.pascii "A5"
 
 	; MSG_CHIP_REVISION_ID_BEGIN
+	.section .text.MSG_CHIP_REVISION_ID_BEGIN, code
+	.global _MSG_CHIP_REVISION_ID_BEGIN_str
+_MSG_CHIP_REVISION_ID_BEGIN_str:
 	.pascii " (24FJ256GB106 "
 
 	; MSG_CHIP_REVISION_UNKNOWN
+	.section .text.MSG_CHIP_REVISION_UNKNOWN, code
+	.global _MSG_CHIP_REVISION_UNKNOWN_str
+_MSG_CHIP_REVISION_UNKNOWN_str:
 	.pascii "UNK"
 
 	; MSG_CLUTCH_DISENGAGED
+	.section .text.MSG_CLUTCH_DISENGAGED, code
+	.global _MSG_CLUTCH_DISENGAGED_str
+_MSG_CLUTCH_DISENGAGED_str:
 	.pascii "Clutch disengaged!!!"
 
 	; MSG_CLUTCH_ENGAGED
+	.section .text.MSG_CLUTCH_ENGAGED, code
+	.global _MSG_CLUTCH_ENGAGED_str
+_MSG_CLUTCH_ENGAGED_str:
 	.pascii "Clutch engaged!!!"
 
 	; MSG_FINISH_SETUP_PROMPT
+	.section .text.MSG_FINISH_SETUP_PROMPT, code
+	.global _MSG_FINISH_SETUP_PROMPT_str
+_MSG_FINISH_SETUP_PROMPT_str:
 	.pascii "To finish setup, start up the power supplies with command 'W'"
 
 	; MSG_HEXADECIMAL_NUMBER_PREFIX
+	.section .text.MSG_HEXADECIMAL_NUMBER_PREFIX, code
+	.global _MSG_HEXADECIMAL_NUMBER_PREFIX_str
+_MSG_HEXADECIMAL_NUMBER_PREFIX_str:
 	.pascii "0x"
 
 	; MSG_I2C_MODE_IDENTIFIER
+	.section .text.MSG_I2C_MODE_IDENTIFIER, code
+	.global _MSG_I2C_MODE_IDENTIFIER_str
+_MSG_I2C_MODE_IDENTIFIER_str:
 	.pascii "I2C1"
 
 	; MSG_I2C_PINS_STATE
+	.section .text.MSG_I2C_PINS_STATE, code
+	.global _MSG_I2C_PINS_STATE_str
+_MSG_I2C_PINS_STATE_str:
 	.pascii "-\t-\tSCL\tSDA"
 
 	; MSG_I2C_READ_ADDRESS_END
+	.section .text.MSG_I2C_READ_ADDRESS_END, code
+	.global _MSG_I2C_READ_ADDRESS_END_str
+_MSG_I2C_READ_ADDRESS_END_str:
 	.pascii " R) "
 
 	; MSG_I2C_START_BIT
+	.section .text.MSG_I2C_START_BIT, code
+	.global _MSG_I2C_START_BIT_str
+_MSG_I2C_START_BIT_str:
 	.pascii "I2C START BIT"
 
 	; MSG_I2C_STOP_BIT
+	.section .text.MSG_I2C_STOP_BIT, code
+	.global _MSG_I2C_STOP_BIT_str
+_MSG_I2C_STOP_BIT_str:
 	.pascii "I2C STOP BIT"
 
 	; MSG_I2C_WRITE_ADDRESS_END
+	.section .text.MSG_I2C_WRITE_ADDRESS_END, code
+	.global _MSG_I2C_WRITE_ADDRESS_END_str
+_MSG_I2C_WRITE_ADDRESS_END_str:
 	.pascii " W) "
 
 	; MSG_MODE_HEADER_END
+	.section .text.MSG_MODE_HEADER_END, code
+	.global _MSG_MODE_HEADER_END_str
+_MSG_MODE_HEADER_END_str:
 	.pascii " )"
 
 	; MSG_NACK
+	.section .text.MSG_NACK, code
+	.global _MSG_NACK_str
+_MSG_NACK_str:
 	.pascii "NACK"
 
 	; MSG_NO_VOLTAGE_ON_PULLUP_PIN
+	.section .text.MSG_NO_VOLTAGE_ON_PULLUP_PIN, code
+	.global _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str
+_MSG_NO_VOLTAGE_ON_PULLUP_PIN_str:
 	.pascii "Warning: no voltage on Vpullup pin"
 
 	; MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED
+	.section .text.MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED, code
+	.global _MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str
+_MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str:
 	.pascii "On-board EEPROM write protect disabled"
 
 	; MSG_PIC_MODE_IDENTIFIER
+	.section .text.MSG_PIC_MODE_IDENTIFIER, code
+	.global _MSG_PIC_MODE_IDENTIFIER_str
+_MSG_PIC_MODE_IDENTIFIER_str:
 	.pascii "PIC1"
 
 	; MSG_PIC_UNKNOWN_MODE
+	.section .text.MSG_PIC_UNKNOWN_MODE, code
+	.global _MSG_PIC_UNKNOWN_MODE_str
+_MSG_PIC_UNKNOWN_MODE_str:
 	.pascii "unknown mode"
 
 	; MSG_PIN_OUTPUT_TYPE_PROMPT
+	.section .text.MSG_PIN_OUTPUT_TYPE_PROMPT, code
+	.global _MSG_PIN_OUTPUT_TYPE_PROMPT_str
+_MSG_PIN_OUTPUT_TYPE_PROMPT_str:
 	.pascii "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
 
 	; MSG_PWM_FREQUENCY_TOO_LOW
+	.section .text.MSG_PWM_FREQUENCY_TOO_LOW, code
+	.global _MSG_PWM_FREQUENCY_TOO_LOW_str
+_MSG_PWM_FREQUENCY_TOO_LOW_str:
 	.pascii "Frequencies < 1Hz are not supported."
 
 	; MSG_PWM_HZ_MARKER
+	.section .text.MSG_PWM_HZ_MARKER, code
+	.global _MSG_PWM_HZ_MARKER_str
+_MSG_PWM_HZ_MARKER_str:
 	.pascii " Hz"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str
+_MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str:
 	.pascii "Data units: "
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str
+_MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str:
 	.pascii "no indication"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH
+	.section .text.MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH, code
+	.global _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str
+_MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str:
 	.pascii "Data unit length (bits): "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str:
 	.pascii "2 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str:
 	.pascii "3 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str:
 	.pascii "Protocol: "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str:
 	.pascii "serial"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN
+	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN, code
+	.global _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str
+_MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str:
 	.pascii "unknown"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str:
 	.pascii "Read type: "
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_TO_END
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_TO_END, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str:
 	.pascii "to end"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH
+	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH, code
+	.global _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str
+_MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str:
 	.pascii "variable length"
 
 	; MSG_RAW2WIRE_ATR_REPLY_HEADER
+	.section .text.MSG_RAW2WIRE_ATR_REPLY_HEADER, code
+	.global _MSG_RAW2WIRE_ATR_REPLY_HEADER_str
+_MSG_RAW2WIRE_ATR_REPLY_HEADER_str:
 	.pascii "ISO 7816-3 reply (uses current LSB setting): "
 
 	; MSG_RAW2WIRE_ATR_RFU
+	.section .text.MSG_RAW2WIRE_ATR_RFU, code
+	.global _MSG_RAW2WIRE_ATR_RFU_str
+_MSG_RAW2WIRE_ATR_RFU_str:
 	.pascii "RFU"
 
 	; MSG_RAW2WIRE_ATR_TRIGGER_INFO
+	.section .text.MSG_RAW2WIRE_ATR_TRIGGER_INFO, code
+	.global _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str
+_MSG_RAW2WIRE_ATR_TRIGGER_INFO_str:
 	.pascii "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
 
 	; MSG_RAW2WIRE_I2C_START
+	.section .text.MSG_RAW2WIRE_I2C_START, code
+	.global _MSG_RAW2WIRE_I2C_START_str
+_MSG_RAW2WIRE_I2C_START_str:
 	.pascii "(\\-/_\\-)"
 
 	; MSG_RAW2WIRE_I2C_STOP
+	.section .text.MSG_RAW2WIRE_I2C_STOP, code
+	.global _MSG_RAW2WIRE_I2C_STOP_str
+_MSG_RAW2WIRE_I2C_STOP_str:
 	.pascii "(\\_/-)"
 
 	; MSG_RAW2WIRE_MACRO_MENU
+	.section .text.MSG_RAW2WIRE_MACRO_MENU, code
+	.global _MSG_RAW2WIRE_MACRO_MENU_str
+_MSG_RAW2WIRE_MACRO_MENU_str:
 	.pascii " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
 
 	; MSG_RAW2WIRE_MODE_HEADER
+	.section .text.MSG_RAW2WIRE_MODE_HEADER, code
+	.global _MSG_RAW2WIRE_MODE_HEADER_str
+_MSG_RAW2WIRE_MODE_HEADER_str:
 	.pascii "R2W (spd hiz)=( "
 
 	; MSG_RAW3WIRE_MODE_HEADER
+	.section .text.MSG_RAW3WIRE_MODE_HEADER, code
+	.global _MSG_RAW3WIRE_MODE_HEADER_str
+_MSG_RAW3WIRE_MODE_HEADER_str:
 	.pascii "R3W (spd csl hiz)=( "
 
 	; MSG_RAW_BRG_VALUE_INPUT
+	.section .text.MSG_RAW_BRG_VALUE_INPUT, code
+	.global _MSG_RAW_BRG_VALUE_INPUT_str
+_MSG_RAW_BRG_VALUE_INPUT_str:
 	.pascii "Enter raw value for BRG"
 
 	; MSG_RAW_MODE_IDENTIFIER
+	.section .text.MSG_RAW_MODE_IDENTIFIER, code
+	.global _MSG_RAW_MODE_IDENTIFIER_str
+_MSG_RAW_MODE_IDENTIFIER_str:
 	.pascii "RAW1"
 
 	; MSG_RESET_MESSAGE
+	.section .text.MSG_RESET_MESSAGE, code
+	.global _MSG_RESET_MESSAGE_str
+_MSG_RESET_MESSAGE_str:
 	.pascii "RESET"
 
 	; MSG_SOFTWARE_MODE_SPEED_PROMPT
+	.section .text.MSG_SOFTWARE_MODE_SPEED_PROMPT, code
+	.global _MSG_SOFTWARE_MODE_SPEED_PROMPT_str
+_MSG_SOFTWARE_MODE_SPEED_PROMPT_str:
 	.pascii "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
 
 	; MSG_SPI_COULD_NOT_KEEP_UP
+	.section .text.MSG_SPI_COULD_NOT_KEEP_UP, code
+	.global _MSG_SPI_COULD_NOT_KEEP_UP_str
+_MSG_SPI_COULD_NOT_KEEP_UP_str:
 	.pascii "Couldn't keep up"
 
 	; MSG_SPI_CS_DISABLED
+	.section .text.MSG_SPI_CS_DISABLED, code
+	.global _MSG_SPI_CS_DISABLED_str
+_MSG_SPI_CS_DISABLED_str:
 	.pascii "CS DISABLED"
 
 	; MSG_SPI_CS_ENABLED
+	.section .text.MSG_SPI_CS_ENABLED, code
+	.global _MSG_SPI_CS_ENABLED_str
+_MSG_SPI_CS_ENABLED_str:
 	.pascii "CS ENABLED"
 
 	; MSG_SPI_CS_MODE_PROMPT
+	.section .text.MSG_SPI_CS_MODE_PROMPT, code
+	.global _MSG_SPI_CS_MODE_PROMPT_str
+_MSG_SPI_CS_MODE_PROMPT_str:
 	.pascii "CS:\r\n 1. CS\r\n 2. /CS *default"
 
 	; MSG_SPI_MODE_IDENTIFIER
+	.section .text.MSG_SPI_MODE_IDENTIFIER, code
+	.global _MSG_SPI_MODE_IDENTIFIER_str
+_MSG_SPI_MODE_IDENTIFIER_str:
 	.pascii "SPI1"
 
 	; MSG_SPI_PINS_STATE
+	.section .text.MSG_SPI_PINS_STATE, code
+	.global _MSG_SPI_PINS_STATE_str
+_MSG_SPI_PINS_STATE_str:
 	.pascii "CS\tMISO\tCLK\tMOSI"
 
 	; MSG_UART_MODE_IDENTIFIER
+	.section .text.MSG_UART_MODE_IDENTIFIER, code
+	.global _MSG_UART_MODE_IDENTIFIER_str
+_MSG_UART_MODE_IDENTIFIER_str:
 	.pascii "ART1"
 
 	; MSG_UART_NORMAL_TO_EXIT
+	.section .text.MSG_UART_NORMAL_TO_EXIT, code
+	.global _MSG_UART_NORMAL_TO_EXIT_str
+_MSG_UART_NORMAL_TO_EXIT_str:
 	.pascii "Normal to exit"
 
 	; MSG_UART_PINS_STATE
+	.section .text.MSG_UART_PINS_STATE, code
+	.global _MSG_UART_PINS_STATE_str
+_MSG_UART_PINS_STATE_str:
 	.pascii "-\tRxD\t-\tTxD"
 
 	; MSG_UNKNOWN_MACRO_ERROR
+	.section .text.MSG_UNKNOWN_MACRO_ERROR, code
+	.global _MSG_UNKNOWN_MACRO_ERROR_str
+_MSG_UNKNOWN_MACRO_ERROR_str:
 	.pascii "Unknown macro, try ? or (0) for help"
 
 	; MSG_USING_ONBOARD_I2C_EEPROM
+	.section .text.MSG_USING_ONBOARD_I2C_EEPROM, code
+	.global _MSG_USING_ONBOARD_I2C_EEPROM_str
+_MSG_USING_ONBOARD_I2C_EEPROM_str:
 	.pascii "Now using on-board EEPROM I2C interface"
 
 	; MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT
+	.section .text.MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT, code
+	.global _MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str
+_MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str:
 	.pascii "Warning: already a voltage on Vpullup pin"
 
 	; MSG_VPU_3V3_MARKER
+	.section .text.MSG_VPU_3V3_MARKER, code
+	.global _MSG_VPU_3V3_MARKER_str
+_MSG_VPU_3V3_MARKER_str:
 	.pascii "Vpu=3V3, "
 
 	; MSG_VPU_5V_MARKER
+	.section .text.MSG_VPU_5V_MARKER, code
+	.global _MSG_VPU_5V_MARKER_str
+_MSG_VPU_5V_MARKER_str:
 	.pascii "Vpu=5V, "
 
 	; MSG_VREG_TOO_LOW
+	.section .text.MSG_VREG_TOO_LOW, code
+	.global _MSG_VREG_TOO_LOW_str
+_MSG_VREG_TOO_LOW_str:
 	.pascii "VREG too low, is there a short?"
 
 	; MSG_XSV1_MODE_IDENTIFIER
+	.section .text.MSG_XSV1_MODE_IDENTIFIER, code
+	.global _MSG_XSV1_MODE_IDENTIFIER_str
+_MSG_XSV1_MODE_IDENTIFIER_str:
 	.pascii "XSV1"
 


### PR DESCRIPTION
Change string packer to place each string in a separate section.
Change message functions to take a pointer instead of an offset.
Enable linker garbage collection in project settings.

Fixes #20