### PR TITLE
Use full addresses for printing constant messages

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -18,34 +18,35 @@
 
 #include "base.h"
 
-void bp_message_write_buffer(void (*strptr)(void), size_t length) {
+void bp_message_write_buffer(unsigned long strptr, size_t length) {
     size_t index;
-    size_t str = (size_t)strptr;
+    unsigned char tblpag_prev = TBLPAG;
 
     for (index = 0; index < length; index++) {
+        TBLPAG = (strptr >> 16) & 0xFF;
         switch (index % 3) {
             case 0:
-               UART1TX(__builtin_tblrdl(str+((index/3)<< 1))
-                       & 0xFF);
-               break;
+                UART1TX(__builtin_tblrdl(strptr) & 0xFF);
+                break;
 
             case 1:
-                UART1TX((__builtin_tblrdl(str+((index/3)<< 1)) >> 8)
-                        & 0xFF);
+                UART1TX((__builtin_tblrdl(strptr) >> 8) & 0xFF);
                 break;
 
             case 2:
-                UART1TX(__builtin_tblrdh(str+((index/3)<< 1))
-                        & 0xFF);
+                UART1TX(__builtin_tblrdh(strptr) & 0xFF);
+                strptr += 2;
                 break;
 
             default:
                 break;
         }
     }
+
+    TBLPAG = tblpag_prev;
 }
 
-void bp_message_write_line(void (*strptr)(void), size_t length) {
+void bp_message_write_line(unsigned long strptr, size_t length) {
     bp_message_write_buffer(strptr, length);
     bpBR;
 }

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -42,7 +42,7 @@ void print_help(void);
  * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_buffer(void (*strptr)(void), size_t length);
+void bp_message_write_buffer(unsigned long strptr, size_t length);
 
 /**
  * Prints a given byte array range from the packed string buffer to the serial
@@ -51,7 +51,7 @@ void bp_message_write_buffer(void (*strptr)(void), size_t length);
  * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_line(void (*strptr)(void), size_t length);
+void bp_message_write_line(unsigned long strptr, size_t length);
 
 /**
  * Prompts the user to agree or not on a particular question.

--- a/Firmware/messages_v3.h
+++ b/Firmware/messages_v3.h
@@ -2,566 +2,566 @@
 #define BP_MESSAGES_V3_H
 
 void BPMSG1004_str(void);
-#define BPMSG1004 bp_message_write_line(BPMSG1004_str, 41)
+#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str), 41)
 void BPMSG1005_str(void);
-#define BPMSG1005 bp_message_write_buffer(BPMSG1005_str, 14)
+#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str), 14)
 void BPMSG1006_str(void);
-#define BPMSG1006 bp_message_write_line(BPMSG1006_str, 13)
+#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str), 13)
 void BPMSG1007_str(void);
-#define BPMSG1007 bp_message_write_line(BPMSG1007_str, 23)
+#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str), 23)
 void BPMSG1008_str(void);
-#define BPMSG1008 bp_message_write_buffer(BPMSG1008_str, 6)
+#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str), 6)
 void BPMSG1009_str(void);
-#define BPMSG1009 bp_message_write_line(BPMSG1009_str, 211)
+#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str), 211)
 void BPMSG1010_str(void);
-#define BPMSG1010 bp_message_write_line(BPMSG1010_str, 19)
+#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str), 19)
 void BPMSG1011_str(void);
-#define BPMSG1011 bp_message_write_line(BPMSG1011_str, 13)
+#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str), 13)
 void BPMSG1012_str(void);
-#define BPMSG1012 bp_message_write_line(BPMSG1012_str, 43)
+#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str), 43)
 void BPMSG1013_str(void);
-#define BPMSG1013 bp_message_write_buffer(BPMSG1013_str, 17)
+#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str), 17)
 void BPMSG1014_str(void);
-#define BPMSG1014 bp_message_write_line(BPMSG1014_str, 16)
+#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str), 16)
 void BPMSG1015_str(void);
-#define BPMSG1015 bp_message_write_line(BPMSG1015_str, 15)
+#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str), 15)
 void BPMSG1017_str(void);
-#define BPMSG1017 bp_message_write_buffer(BPMSG1017_str, 10)
+#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str), 10)
 void BPMSG1019_str(void);
-#define BPMSG1019 bp_message_write_buffer(BPMSG1019_str, 9)
+#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str), 9)
 void BPMSG1020_str(void);
-#define BPMSG1020 bp_message_write_buffer(BPMSG1020_str, 21)
+#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str), 21)
 void BPMSG1021_str(void);
-#define BPMSG1021 bp_message_write_buffer(BPMSG1021_str, 20)
+#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str), 20)
 void BPMSG1022_str(void);
-#define BPMSG1022 bp_message_write_buffer(BPMSG1022_str, 27)
+#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str), 27)
 void BPMSG1023_str(void);
-#define BPMSG1023 bp_message_write_buffer(BPMSG1023_str, 26)
+#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str), 26)
 void BPMSG1024_str(void);
-#define BPMSG1024 bp_message_write_buffer(BPMSG1024_str, 21)
+#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str), 21)
 void BPMSG1025_str(void);
-#define BPMSG1025 bp_message_write_buffer(BPMSG1025_str, 24)
+#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str), 24)
 void BPMSG1026_str(void);
-#define BPMSG1026 bp_message_write_buffer(BPMSG1026_str, 16)
+#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str), 16)
 void BPMSG1027_str(void);
-#define BPMSG1027 bp_message_write_buffer(BPMSG1027_str, 14)
+#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str), 14)
 void BPMSG1028_str(void);
-#define BPMSG1028 bp_message_write_line(BPMSG1028_str, 12)
+#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str), 12)
 void BPMSG1029_str(void);
-#define BPMSG1029 bp_message_write_line(BPMSG1029_str, 17)
+#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str), 17)
 void BPMSG1030_str(void);
-#define BPMSG1030 bp_message_write_buffer(BPMSG1030_str, 17)
+#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str), 17)
 void BPMSG1033_str(void);
-#define BPMSG1033 bp_message_write_buffer(BPMSG1033_str, 16)
+#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str), 16)
 void BPMSG1034_str(void);
-#define BPMSG1034 bp_message_write_line(BPMSG1034_str, 10)
+#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str), 10)
 void BPMSG1037_str(void);
-#define BPMSG1037 bp_message_write_line(BPMSG1037_str, 31)
+#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str), 31)
 void BPMSG1038_str(void);
-#define BPMSG1038 bp_message_write_buffer(BPMSG1038_str, 15)
+#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str), 15)
 void BPMSG1039_str(void);
-#define BPMSG1039 bp_message_write_buffer(BPMSG1039_str, 14)
+#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str), 14)
 void BPMSG1040_str(void);
-#define BPMSG1040 bp_message_write_line(BPMSG1040_str, 8)
+#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str), 8)
 void BPMSG1041_str(void);
-#define BPMSG1041 bp_message_write_line(BPMSG1041_str, 7)
+#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str), 7)
 void BPMSG1042_str(void);
-#define BPMSG1042 bp_message_write_line(BPMSG1042_str, 14)
+#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str), 14)
 void BPMSG1044_str(void);
-#define BPMSG1044 bp_message_write_buffer(BPMSG1044_str, 15)
+#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str), 15)
 void BPMSG1045_str(void);
-#define BPMSG1045 bp_message_write_buffer(BPMSG1045_str, 1)
+#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str), 1)
 void BPMSG1047_str(void);
-#define BPMSG1047 bp_message_write_buffer(BPMSG1047_str, 6)
+#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str), 6)
 void BPMSG1048_str(void);
-#define BPMSG1048 bp_message_write_buffer(BPMSG1048_str, 8)
+#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str), 8)
 void BPMSG1049_str(void);
-#define BPMSG1049 bp_message_write_buffer(BPMSG1049_str, 11)
+#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str), 11)
 void BPMSG1050_str(void);
-#define BPMSG1050 bp_message_write_line(BPMSG1050_str, 7)
+#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str), 7)
 void BPMSG1051_str(void);
-#define BPMSG1051 bp_message_write_line(BPMSG1051_str, 9)
+#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str), 9)
 void BPMSG1052_str(void);
-#define BPMSG1052 bp_message_write_line(BPMSG1052_str, 12)
+#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str), 12)
 void BPMSG1059_str(void);
-#define BPMSG1059 bp_message_write_line(BPMSG1059_str, 33)
+#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str), 33)
 void BPMSG1064_str(void);
-#define BPMSG1064 bp_message_write_line(BPMSG1064_str, 37)
+#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str), 37)
 void BPMSG1066_str(void);
-#define BPMSG1066 bp_message_write_buffer(BPMSG1066_str, 53)
+#define BPMSG1066 bp_message_write_buffer(__builtin_tbladdress(BPMSG1066_str), 53)
 void BPMSG1067_str(void);
-#define BPMSG1067 bp_message_write_buffer(BPMSG1067_str, 44)
+#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str), 44)
 void BPMSG1068_str(void);
-#define BPMSG1068 bp_message_write_buffer(BPMSG1068_str, 16)
+#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str), 16)
 void BPMSG1069_str(void);
-#define BPMSG1069 bp_message_write_buffer(BPMSG1069_str, 53)
+#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str), 53)
 void BPMSG1070_str(void);
-#define BPMSG1070 bp_message_write_line(BPMSG1070_str, 46)
+#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str), 46)
 void BPMSG1072_str(void);
-#define BPMSG1072 bp_message_write_line(BPMSG1072_str, 34)
+#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str), 34)
 void BPMSG1073_str(void);
-#define BPMSG1073 bp_message_write_line(BPMSG1073_str, 6)
+#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str), 6)
 void BPMSG1074_str(void);
-#define BPMSG1074 bp_message_write_buffer(BPMSG1074_str, 14)
+#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str), 14)
 void BPMSG1075_str(void);
-#define BPMSG1075 bp_message_write_buffer(BPMSG1075_str, 3)
+#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str), 3)
 void BPMSG1076_str(void);
-#define BPMSG1076 bp_message_write_line(BPMSG1076_str, 3)
+#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str), 3)
 void BPMSG1077_str(void);
-#define BPMSG1077 bp_message_write_line(BPMSG1077_str, 7)
+#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str), 7)
 void BPMSG1078_str(void);
-#define BPMSG1078 bp_message_write_line(BPMSG1078_str, 12)
+#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str), 12)
 void BPMSG1079_str(void);
-#define BPMSG1079 bp_message_write_line(BPMSG1079_str, 13)
+#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str), 13)
 void BPMSG1080_str(void);
-#define BPMSG1080 bp_message_write_buffer(BPMSG1080_str, 8)
+#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str), 8)
 void BPMSG1081_str(void);
-#define BPMSG1081 bp_message_write_buffer(BPMSG1081_str, 7)
+#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str), 7)
 void BPMSG1082_str(void);
-#define BPMSG1082 bp_message_write_line(BPMSG1082_str, 21)
+#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str), 21)
 void BPMSG1083_str(void);
-#define BPMSG1083 bp_message_write_line(BPMSG1083_str, 32)
+#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str), 32)
 void BPMSG1084_str(void);
-#define BPMSG1084 bp_message_write_buffer(BPMSG1084_str, 7)
+#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str), 7)
 void BPMSG1085_str(void);
-#define BPMSG1085 bp_message_write_line(BPMSG1085_str, 5)
+#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str), 5)
 void BPMSG1086_str(void);
-#define BPMSG1086 bp_message_write_line(BPMSG1086_str, 22)
+#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str), 22)
 void BPMSG1087_str(void);
-#define BPMSG1087 bp_message_write_line(BPMSG1087_str, 21)
+#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str), 21)
 void BPMSG1088_str(void);
-#define BPMSG1088 bp_message_write_line(BPMSG1088_str, 29)
+#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str), 29)
 void BPMSG1089_str(void);
-#define BPMSG1089 bp_message_write_buffer(BPMSG1089_str, 21)
+#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str), 21)
 void BPMSG1091_str(void);
-#define BPMSG1091 bp_message_write_buffer(BPMSG1091_str, 20)
+#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str), 20)
 void BPMSG1092_str(void);
-#define BPMSG1092 bp_message_write_line(BPMSG1092_str, 26)
+#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str), 26)
 void BPMSG1093_str(void);
-#define BPMSG1093 bp_message_write_line(BPMSG1093_str, 5)
+#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str), 5)
 void BPMSG1094_str(void);
-#define BPMSG1094 bp_message_write_line(BPMSG1094_str, 10)
+#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str), 10)
 void BPMSG1095_str(void);
-#define BPMSG1095 bp_message_write_buffer(BPMSG1095_str, 22)
+#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str), 22)
 void BPMSG1096_str(void);
-#define BPMSG1096 bp_message_write_buffer(BPMSG1096_str, 17)
+#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str), 17)
 void BPMSG1097_str(void);
-#define BPMSG1097 bp_message_write_buffer(BPMSG1097_str, 18)
+#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str), 18)
 void BPMSG1098_str(void);
-#define BPMSG1098 bp_message_write_buffer(BPMSG1098_str, 12)
+#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str), 12)
 void BPMSG1099_str(void);
-#define BPMSG1099 bp_message_write_buffer(BPMSG1099_str, 6)
+#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str), 6)
 void BPMSG1100_str(void);
-#define BPMSG1100 bp_message_write_line(BPMSG1100_str, 2)
+#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str), 2)
 void BPMSG1101_str(void);
-#define BPMSG1101 bp_message_write_buffer(BPMSG1101_str, 7)
+#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str), 7)
 void BPMSG1102_str(void);
-#define BPMSG1102 bp_message_write_buffer(BPMSG1102_str, 6)
+#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str), 6)
 void BPMSG1103_str(void);
-#define BPMSG1103 bp_message_write_line(BPMSG1103_str, 8)
+#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str), 8)
 void BPMSG1104_str(void);
-#define BPMSG1104 bp_message_write_line(BPMSG1104_str, 8)
+#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str), 8)
 void BPMSG1105_str(void);
-#define BPMSG1105 bp_message_write_line(BPMSG1105_str, 14)
+#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str), 14)
 void BPMSG1106_str(void);
-#define BPMSG1106 bp_message_write_line(BPMSG1106_str, 14)
+#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str), 14)
 void BPMSG1107_str(void);
-#define BPMSG1107 bp_message_write_line(BPMSG1107_str, 16)
+#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str), 16)
 void BPMSG1108_str(void);
-#define BPMSG1108 bp_message_write_buffer(BPMSG1108_str, 13)
+#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str), 13)
 void BPMSG1109_str(void);
-#define BPMSG1109 bp_message_write_buffer(BPMSG1109_str, 10)
+#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str), 10)
 void BPMSG1110_str(void);
-#define BPMSG1110 bp_message_write_buffer(BPMSG1110_str, 21)
+#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str), 21)
 void BPMSG1111_str(void);
-#define BPMSG1111 bp_message_write_line(BPMSG1111_str, 23)
+#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str), 23)
 void BPMSG1112_str(void);
-#define BPMSG1112 bp_message_write_line(BPMSG1112_str, 14)
+#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str), 14)
 void BPMSG1114_str(void);
-#define BPMSG1114 bp_message_write_line(BPMSG1114_str, 21)
+#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str), 21)
 void BPMSG1115_str(void);
-#define BPMSG1115 bp_message_write_line(BPMSG1115_str, 7)
+#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str), 7)
 void BPMSG1117_str(void);
-#define BPMSG1117 bp_message_write_buffer(BPMSG1117_str, 6)
+#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str), 6)
 void BPMSG1118_str(void);
-#define BPMSG1118 bp_message_write_line(BPMSG1118_str, 30)
+#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str), 30)
 void BPMSG1119_str(void);
-#define BPMSG1119 bp_message_write_line(BPMSG1119_str, 12)
+#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str), 12)
 void BPMSG1120_str(void);
-#define BPMSG1120 bp_message_write_line(BPMSG1120_str, 34)
+#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str), 34)
 void BPMSG1121_str(void);
-#define BPMSG1121 bp_message_write_line(BPMSG1121_str, 30)
+#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str), 30)
 void BPMSG1123_str(void);
-#define BPMSG1123 bp_message_write_buffer(BPMSG1123_str, 27)
+#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str), 27)
 void BPMSG1124_str(void);
-#define BPMSG1124 bp_message_write_buffer(BPMSG1124_str, 28)
+#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str), 28)
 void BPMSG1126_str(void);
-#define BPMSG1126 bp_message_write_buffer(BPMSG1126_str, 13)
+#define BPMSG1126 bp_message_write_buffer(__builtin_tbladdress(BPMSG1126_str), 13)
 void BPMSG1127_str(void);
-#define BPMSG1127 bp_message_write_line(BPMSG1127_str, 34)
+#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str), 34)
 void BPMSG1128_str(void);
-#define BPMSG1128 bp_message_write_line(BPMSG1128_str, 18)
+#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str), 18)
 void BPMSG1133_str(void);
-#define BPMSG1133 bp_message_write_line(BPMSG1133_str, 141)
+#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str), 141)
 void BPMSG1134_str(void);
-#define BPMSG1134 bp_message_write_line(BPMSG1134_str, 20)
+#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str), 20)
 void BPMSG1135_str(void);
-#define BPMSG1135 bp_message_write_buffer(BPMSG1135_str, 14)
+#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str), 14)
 void BPMSG1136_str(void);
-#define BPMSG1136 bp_message_write_buffer(BPMSG1136_str, 5)
+#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str), 5)
 void BPMSG1137_str(void);
-#define BPMSG1137 bp_message_write_buffer(BPMSG1137_str, 6)
+#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str), 6)
 void BPMSG1163_str(void);
-#define BPMSG1163 bp_message_write_line(BPMSG1163_str, 63)
+#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str), 63)
 void BPMSG1164_str(void);
-#define BPMSG1164 bp_message_write_line(BPMSG1164_str, 4)
+#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str), 4)
 void BPMSG1165_str(void);
-#define BPMSG1165 bp_message_write_buffer(BPMSG1165_str, 3)
+#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str), 3)
 void BPMSG1166_str(void);
-#define BPMSG1166 bp_message_write_buffer(BPMSG1166_str, 8)
+#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str), 8)
 void BPMSG1167_str(void);
-#define BPMSG1167 bp_message_write_buffer(BPMSG1167_str, 8)
+#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str), 8)
 void BPMSG1168_str(void);
-#define BPMSG1168 bp_message_write_buffer(BPMSG1168_str, 8)
+#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str), 8)
 void BPMSG1169_str(void);
-#define BPMSG1169 bp_message_write_buffer(BPMSG1169_str, 4)
+#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str), 4)
 void BPMSG1170_str(void);
-#define BPMSG1170 bp_message_write_line(BPMSG1170_str, 14)
+#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str), 14)
 void BPMSG1171_str(void);
-#define BPMSG1171 bp_message_write_buffer(BPMSG1171_str, 2)
+#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str), 2)
 void BPMSG1172_str(void);
-#define BPMSG1172 bp_message_write_buffer(BPMSG1172_str, 3)
+#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str), 3)
 void BPMSG1173_str(void);
-#define BPMSG1173 bp_message_write_buffer(BPMSG1173_str, 4)
+#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str), 4)
 void BPMSG1174_str(void);
-#define BPMSG1174 bp_message_write_buffer(BPMSG1174_str, 3)
+#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str), 3)
 void BPMSG1175_str(void);
-#define BPMSG1175 bp_message_write_line(BPMSG1175_str, 8)
+#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str), 8)
 void BPMSG1176_str(void);
-#define BPMSG1176 bp_message_write_line(BPMSG1176_str, 10)
+#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str), 10)
 void BPMSG1177_str(void);
-#define BPMSG1177 bp_message_write_line(BPMSG1177_str, 10)
+#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str), 10)
 void BPMSG1178_str(void);
-#define BPMSG1178 bp_message_write_line(BPMSG1178_str, 32)
+#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str), 32)
 void BPMSG1179_str(void);
-#define BPMSG1179 bp_message_write_buffer(BPMSG1179_str, 6)
+#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str), 6)
 void BPMSG1180_str(void);
-#define BPMSG1180 bp_message_write_line(BPMSG1180_str, 8)
+#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str), 8)
 void BPMSG1181_str(void);
-#define BPMSG1181 bp_message_write_buffer(BPMSG1181_str, 4)
+#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str), 4)
 void BPMSG1182_str(void);
-#define BPMSG1182 bp_message_write_buffer(BPMSG1182_str, 3)
+#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str), 3)
 void BPMSG1183_str(void);
-#define BPMSG1183 bp_message_write_buffer(BPMSG1183_str, 4)
+#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str), 4)
 void BPMSG1184_str(void);
-#define BPMSG1184 bp_message_write_buffer(BPMSG1184_str, 2)
+#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str), 2)
 void BPMSG1185_str(void);
-#define BPMSG1185 bp_message_write_line(BPMSG1185_str, 3)
+#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str), 3)
 void BPMSG1186_str(void);
-#define BPMSG1186 bp_message_write_line(BPMSG1186_str, 5)
+#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str), 5)
 void BPMSG1194_str(void);
-#define BPMSG1194 bp_message_write_buffer(BPMSG1194_str, 3)
+#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str), 3)
 void BPMSG1195_str(void);
-#define BPMSG1195 bp_message_write_buffer(BPMSG1195_str, 3)
+#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str), 3)
 void BPMSG1196_str(void);
-#define BPMSG1196 bp_message_write_buffer(BPMSG1196_str, 15)
+#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str), 15)
 void BPMSG1197_str(void);
-#define BPMSG1197 bp_message_write_buffer(BPMSG1197_str, 15)
+#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str), 15)
 void BPMSG1199_str(void);
-#define BPMSG1199 bp_message_write_buffer(BPMSG1199_str, 84)
+#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str), 84)
 void BPMSG1200_str(void);
-#define BPMSG1200 bp_message_write_buffer(BPMSG1200_str, 33)
+#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str), 33)
 void BPMSG1201_str(void);
-#define BPMSG1201 bp_message_write_buffer(BPMSG1201_str, 50)
+#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str), 50)
 void BPMSG1202_str(void);
-#define BPMSG1202 bp_message_write_buffer(BPMSG1202_str, 32)
+#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str), 32)
 void BPMSG1203_str(void);
-#define BPMSG1203 bp_message_write_buffer(BPMSG1203_str, 106)
+#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str), 106)
 void BPMSG1204_str(void);
-#define BPMSG1204 bp_message_write_line(BPMSG1204_str, 11)
+#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str), 11)
 void BPMSG1206_str(void);
-#define BPMSG1206 bp_message_write_line(BPMSG1206_str, 14)
+#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str), 14)
 void BPMSG1207_str(void);
-#define BPMSG1207 bp_message_write_line(BPMSG1207_str, 28)
+#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str), 28)
 void BPMSG1208_str(void);
-#define BPMSG1208 bp_message_write_line(BPMSG1208_str, 20)
+#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str), 20)
 void BPMSG1209_str(void);
-#define BPMSG1209 bp_message_write_line(BPMSG1209_str, 34)
+#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str), 34)
 void BPMSG1210_str(void);
-#define BPMSG1210 bp_message_write_buffer(BPMSG1210_str, 7)
+#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str), 7)
 void BPMSG1211_str(void);
-#define BPMSG1211 bp_message_write_line(BPMSG1211_str, 27)
+#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str), 27)
 void BPMSG1212_str(void);
-#define BPMSG1212 bp_message_write_line(BPMSG1212_str, 2)
+#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str), 2)
 void BPMSG1213_str(void);
-#define BPMSG1213 bp_message_write_line(BPMSG1213_str, 20)
+#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str), 20)
 void BPMSG1214_str(void);
-#define BPMSG1214 bp_message_write_line(BPMSG1214_str, 18)
+#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str), 18)
 void BPMSG1216_str(void);
-#define BPMSG1216 bp_message_write_line(BPMSG1216_str, 29)
+#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str), 29)
 void BPMSG1219_str(void);
-#define BPMSG1219 bp_message_write_line(BPMSG1219_str, 152)
+#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str), 152)
 void BPMSG1220_str(void);
-#define BPMSG1220 bp_message_write_line(BPMSG1220_str, 36)
+#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str), 36)
 void BPMSG1221_str(void);
-#define BPMSG1221 bp_message_write_line(BPMSG1221_str, 4)
+#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str), 4)
 void BPMSG1222_str(void);
-#define BPMSG1222 bp_message_write_line(BPMSG1222_str, 5)
+#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str), 5)
 void BPMSG1223_str(void);
-#define BPMSG1223 bp_message_write_line(BPMSG1223_str, 10)
+#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str), 10)
 void BPMSG1226_str(void);
-#define BPMSG1226 bp_message_write_line(BPMSG1226_str, 10)
+#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str), 10)
 void BPMSG1227_str(void);
-#define BPMSG1227 bp_message_write_buffer(BPMSG1227_str, 26)
+#define BPMSG1227 bp_message_write_buffer(__builtin_tbladdress(BPMSG1227_str), 26)
 void BPMSG1228_str(void);
-#define BPMSG1228 bp_message_write_buffer(BPMSG1228_str, 10)
+#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str), 10)
 void BPMSG1229_str(void);
-#define BPMSG1229 bp_message_write_line(BPMSG1229_str, 9)
+#define BPMSG1229 bp_message_write_line(__builtin_tbladdress(BPMSG1229_str), 9)
 void BPMSG1232_str(void);
-#define BPMSG1232 bp_message_write_line(BPMSG1232_str, 11)
+#define BPMSG1232 bp_message_write_line(__builtin_tbladdress(BPMSG1232_str), 11)
 void BPMSG1233_str(void);
-#define BPMSG1233 bp_message_write_line(BPMSG1233_str, 70)
+#define BPMSG1233 bp_message_write_line(__builtin_tbladdress(BPMSG1233_str), 70)
 void BPMSG1234_str(void);
-#define BPMSG1234 bp_message_write_buffer(BPMSG1234_str, 4)
+#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str), 4)
 void BPMSG1237_str(void);
-#define BPMSG1237 bp_message_write_buffer(BPMSG1237_str, 8)
+#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str), 8)
 void BPMSG1238_str(void);
-#define BPMSG1238 bp_message_write_line(BPMSG1238_str, 38)
+#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str), 38)
 void BPMSG1239_str(void);
-#define BPMSG1239 bp_message_write_line(BPMSG1239_str, 28)
+#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str), 28)
 void BPMSG1240_str(void);
-#define BPMSG1240 bp_message_write_line(BPMSG1240_str, 16)
+#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str), 16)
 void BPMSG1241_str(void);
-#define BPMSG1241 bp_message_write_line(BPMSG1241_str, 14)
+#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str), 14)
 void BPMSG1242_str(void);
-#define BPMSG1242 bp_message_write_line(BPMSG1242_str, 15)
+#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str), 15)
 void BPMSG1243_str(void);
-#define BPMSG1243 bp_message_write_line(BPMSG1243_str, 5)
+#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str), 5)
 void BPMSG1244_str(void);
-#define BPMSG1244 bp_message_write_line(BPMSG1244_str, 14)
+#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str), 14)
 void BPMSG1245_str(void);
-#define BPMSG1245 bp_message_write_buffer(BPMSG1245_str, 11)
+#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str), 11)
 void BPMSG1248_str(void);
-#define BPMSG1248 bp_message_write_line(BPMSG1248_str, 28)
+#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str), 28)
 void BPMSG1251_str(void);
-#define BPMSG1251 bp_message_write_line(BPMSG1251_str, 17)
+#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str), 17)
 void BPMSG1252_str(void);
-#define BPMSG1252 bp_message_write_buffer(BPMSG1252_str, 27)
+#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str), 27)
 void BPMSG1254_str(void);
-#define BPMSG1254 bp_message_write_line(BPMSG1254_str, 19)
+#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str), 19)
 void BPMSG1255_str(void);
-#define BPMSG1255 bp_message_write_line(BPMSG1255_str, 12)
+#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str), 12)
 void BPMSG1280_str(void);
-#define BPMSG1280 bp_message_write_line(BPMSG1280_str, 19)
+#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str), 19)
 void BPMSG1281_str(void);
-#define BPMSG1281 bp_message_write_line(BPMSG1281_str, 14)
+#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str), 14)
 void BPMSG1282_str(void);
-#define BPMSG1282 bp_message_write_line(BPMSG1282_str, 47)
+#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str), 47)
 void BPMSG1283_str(void);
-#define BPMSG1283 bp_message_write_buffer(BPMSG1283_str, 15)
+#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str), 15)
 void BPMSG1284_str(void);
-#define BPMSG1284 bp_message_write_buffer(BPMSG1284_str, 15)
+#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str), 15)
 void BPMSG1285_str(void);
-#define BPMSG1285 bp_message_write_line(BPMSG1285_str, 4)
+#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str), 4)
 void HLP1000_str(void);
-#define HLP1000 bp_message_write_line(HLP1000_str, 33)
+#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str), 33)
 void HLP1001_str(void);
-#define HLP1001 bp_message_write_line(HLP1001_str, 76)
+#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str), 76)
 void HLP1002_str(void);
-#define HLP1002 bp_message_write_line(HLP1002_str, 38)
+#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str), 38)
 void HLP1003_str(void);
-#define HLP1003 bp_message_write_line(HLP1003_str, 40)
+#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str), 40)
 void HLP1004_str(void);
-#define HLP1004 bp_message_write_line(HLP1004_str, 21)
+#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str), 21)
 void HLP1005_str(void);
-#define HLP1005 bp_message_write_line(HLP1005_str, 27)
+#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str), 27)
 void HLP1006_str(void);
-#define HLP1006 bp_message_write_line(HLP1006_str, 40)
+#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str), 40)
 void HLP1007_str(void);
-#define HLP1007 bp_message_write_line(HLP1007_str, 27)
+#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str), 27)
 void HLP1008_str(void);
-#define HLP1008 bp_message_write_line(HLP1008_str, 46)
+#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str), 46)
 void HLP1009_str(void);
-#define HLP1009 bp_message_write_line(HLP1009_str, 21)
+#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str), 21)
 void HLP1010_str(void);
-#define HLP1010 bp_message_write_line(HLP1010_str, 35)
+#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str), 35)
 void HLP1011_str(void);
-#define HLP1011 bp_message_write_line(HLP1011_str, 46)
+#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str), 46)
 void HLP1012_str(void);
-#define HLP1012 bp_message_write_line(HLP1012_str, 28)
+#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str), 28)
 void HLP1013_str(void);
-#define HLP1013 bp_message_write_line(HLP1013_str, 33)
+#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str), 33)
 void HLP1014_str(void);
-#define HLP1014 bp_message_write_line(HLP1014_str, 28)
+#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str), 28)
 void HLP1015_str(void);
-#define HLP1015 bp_message_write_line(HLP1015_str, 37)
+#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str), 37)
 void HLP1016_str(void);
-#define HLP1016 bp_message_write_line(HLP1016_str, 33)
+#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str), 33)
 void HLP1017_str(void);
-#define HLP1017 bp_message_write_line(HLP1017_str, 25)
+#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str), 25)
 void HLP1018_str(void);
-#define HLP1018 bp_message_write_line(HLP1018_str, 31)
+#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str), 31)
 void HLP1019_str(void);
-#define HLP1019 bp_message_write_line(HLP1019_str, 41)
+#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str), 41)
 void HLP1020_str(void);
-#define HLP1020 bp_message_write_line(HLP1020_str, 37)
+#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str), 37)
 void HLP1021_str(void);
-#define HLP1021 bp_message_write_line(HLP1021_str, 54)
+#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str), 54)
 void HLP1022_str(void);
-#define HLP1022 bp_message_write_line(HLP1022_str, 62)
+#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str), 62)
 void MSG_1WIRE_MODE_IDENTIFIER_str(void);
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(MSG_1WIRE_MODE_IDENTIFIER_str, 4)
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str), 4)
 void MSG_1WIRE_NEXT_CLOCK_ALERT_str(void);
-#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(MSG_1WIRE_NEXT_CLOCK_ALERT_str, 36)
+#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str), 36)
 void MSG_1WIRE_SPEED_PROMPT_str(void);
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(MSG_1WIRE_SPEED_PROMPT_str, 62)
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str), 62)
 void MSG_ACK_str(void);
-#define MSG_ACK bp_message_write_buffer(MSG_ACK_str, 3)
+#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str), 3)
 void MSG_ANY_KEY_TO_EXIT_PROMPT_str(void);
-#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(MSG_ANY_KEY_TO_EXIT_PROMPT_str, 15)
+#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str), 15)
 void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(MSG_BASE_CONVERTER_EQUAL_SIGN_str, 3)
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str), 3)
 void MSG_BBIO_MODE_IDENTIFIER_str(void);
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(MSG_BBIO_MODE_IDENTIFIER_str, 5)
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str), 5)
 void MSG_BINARY_NUMBER_PREFIX_str(void);
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(MSG_BINARY_NUMBER_PREFIX_str, 2)
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str), 2)
 void MSG_CHIP_IDENTIFIER_CLONE_str(void);
-#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(MSG_CHIP_IDENTIFIER_CLONE_str, 22)
+#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_IDENTIFIER_CLONE_str), 22)
 void MSG_CHIP_REVISION_A3_str(void);
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(MSG_CHIP_REVISION_A3_str, 2)
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str), 2)
 void MSG_CHIP_REVISION_B4_str(void);
-#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(MSG_CHIP_REVISION_B4_str, 2)
+#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B4_str), 2)
 void MSG_CHIP_REVISION_B5_str(void);
-#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(MSG_CHIP_REVISION_B5_str, 2)
+#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B5_str), 2)
 void MSG_CHIP_REVISION_B8_str(void);
-#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(MSG_CHIP_REVISION_B8_str, 2)
+#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B8_str), 2)
 void MSG_CHIP_REVISION_ID_BEGIN_str(void);
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(MSG_CHIP_REVISION_ID_BEGIN_str, 13)
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str), 13)
 void MSG_CHIP_REVISION_ID_END_2_str(void);
-#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(MSG_CHIP_REVISION_ID_END_2_str, 2)
+#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_2_str), 2)
 void MSG_CHIP_REVISION_ID_END_4_str(void);
-#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(MSG_CHIP_REVISION_ID_END_4_str, 2)
+#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_4_str), 2)
 void MSG_CHIP_REVISION_UNKNOWN_str(void);
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(MSG_CHIP_REVISION_UNKNOWN_str, 3)
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str), 3)
 void MSG_CLUTCH_DISENGAGED_str(void);
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(MSG_CLUTCH_DISENGAGED_str, 20)
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str), 20)
 void MSG_CLUTCH_ENGAGED_str(void);
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(MSG_CLUTCH_ENGAGED_str, 17)
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str), 17)
 void MSG_FINISH_SETUP_PROMPT_str(void);
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(MSG_FINISH_SETUP_PROMPT_str, 61)
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str), 61)
 void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(MSG_HEXADECIMAL_NUMBER_PREFIX_str, 2)
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str), 2)
 void MSG_I2C_MODE_IDENTIFIER_str(void);
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(MSG_I2C_MODE_IDENTIFIER_str, 4)
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str), 4)
 void MSG_I2C_PINS_STATE_str(void);
-#define MSG_I2C_PINS_STATE bp_message_write_line(MSG_I2C_PINS_STATE_str, 11)
+#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str), 11)
 void MSG_I2C_READ_ADDRESS_END_str(void);
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(MSG_I2C_READ_ADDRESS_END_str, 4)
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str), 4)
 void MSG_I2C_START_BIT_str(void);
-#define MSG_I2C_START_BIT bp_message_write_line(MSG_I2C_START_BIT_str, 13)
+#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str), 13)
 void MSG_I2C_STOP_BIT_str(void);
-#define MSG_I2C_STOP_BIT bp_message_write_line(MSG_I2C_STOP_BIT_str, 12)
+#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str), 12)
 void MSG_I2C_WRITE_ADDRESS_END_str(void);
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(MSG_I2C_WRITE_ADDRESS_END_str, 4)
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str), 4)
 void MSG_MODE_HEADER_END_str(void);
-#define MSG_MODE_HEADER_END bp_message_write_line(MSG_MODE_HEADER_END_str, 2)
+#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str), 2)
 void MSG_NACK_str(void);
-#define MSG_NACK bp_message_write_buffer(MSG_NACK_str, 4)
+#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str), 4)
 void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str, 34)
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str), 34)
 void MSG_OPENOCD_MODE_IDENTIFIER_str(void);
-#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(MSG_OPENOCD_MODE_IDENTIFIER_str, 4)
+#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_OPENOCD_MODE_IDENTIFIER_str), 4)
 void MSG_PIC_MODE_IDENTIFIER_str(void);
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(MSG_PIC_MODE_IDENTIFIER_str, 4)
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str), 4)
 void MSG_PIC_UNKNOWN_MODE_str(void);
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(MSG_PIC_UNKNOWN_MODE_str, 12)
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str), 12)
 void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(MSG_PIN_OUTPUT_TYPE_PROMPT_str, 79)
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str), 79)
 void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(MSG_PWM_FREQUENCY_TOO_LOW_str, 36)
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str), 36)
 void MSG_PWM_HZ_MARKER_str(void);
-#define MSG_PWM_HZ_MARKER bp_message_write_line(MSG_PWM_HZ_MARKER_str, 3)
+#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str), 3)
 void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str, 12)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str), 12)
 void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str, 13)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str), 13)
 void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str, 25)
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str), 25)
 void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str, 10)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str), 10)
 void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str, 7)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str), 7)
 void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str, 11)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str), 11)
 void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str, 6)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str), 6)
 void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str, 15)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str), 15)
 void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_REPLY_HEADER_str, 45)
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str), 45)
 void MSG_RAW2WIRE_ATR_RFU_str(void);
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(MSG_RAW2WIRE_ATR_RFU_str, 3)
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str), 3)
 void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str, 63)
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str), 63)
 void MSG_RAW2WIRE_I2C_START_str(void);
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(MSG_RAW2WIRE_I2C_START_str, 8)
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str), 8)
 void MSG_RAW2WIRE_I2C_STOP_str(void);
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(MSG_RAW2WIRE_I2C_STOP_str, 6)
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str), 6)
 void MSG_RAW2WIRE_MACRO_MENU_str(void);
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(MSG_RAW2WIRE_MACRO_MENU_str, 56)
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str), 56)
 void MSG_RAW2WIRE_MODE_HEADER_str(void);
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_MODE_HEADER_str, 16)
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str), 16)
 void MSG_RAW3WIRE_MODE_HEADER_str(void);
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW3WIRE_MODE_HEADER_str, 20)
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str), 20)
 void MSG_RAW_BRG_VALUE_INPUT_str(void);
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(MSG_RAW_BRG_VALUE_INPUT_str, 23)
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str), 23)
 void MSG_RAW_MODE_IDENTIFIER_str(void);
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(MSG_RAW_MODE_IDENTIFIER_str, 4)
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str), 4)
 void MSG_SNIFFER_MESSAGE_str(void);
-#define MSG_SNIFFER_MESSAGE bp_message_write_line(MSG_SNIFFER_MESSAGE_str, 7)
+#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str), 7)
 void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(MSG_SOFTWARE_MODE_SPEED_PROMPT_str, 59)
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str), 59)
 void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(MSG_SPI_COULD_NOT_KEEP_UP_str, 16)
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str), 16)
 void MSG_SPI_CS_DISABLED_str(void);
-#define MSG_SPI_CS_DISABLED bp_message_write_line(MSG_SPI_CS_DISABLED_str, 11)
+#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str), 11)
 void MSG_SPI_CS_ENABLED_str(void);
-#define MSG_SPI_CS_ENABLED bp_message_write_line(MSG_SPI_CS_ENABLED_str, 10)
+#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str), 10)
 void MSG_SPI_CS_MODE_PROMPT_str(void);
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(MSG_SPI_CS_MODE_PROMPT_str, 29)
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str), 29)
 void MSG_SPI_EDGE_PROMPT_str(void);
-#define MSG_SPI_EDGE_PROMPT bp_message_write_line(MSG_SPI_EDGE_PROMPT_str, 67)
+#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str), 67)
 void MSG_SPI_MACRO_MENU_str(void);
-#define MSG_SPI_MACRO_MENU bp_message_write_line(MSG_SPI_MACRO_MENU_str, 206)
+#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str), 206)
 void MSG_SPI_MODE_HEADER_START_str(void);
-#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(MSG_SPI_MODE_HEADER_START_str, 32)
+#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str), 32)
 void MSG_SPI_MODE_IDENTIFIER_str(void);
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(MSG_SPI_MODE_IDENTIFIER_str, 4)
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str), 4)
 void MSG_SPI_PINS_STATE_str(void);
-#define MSG_SPI_PINS_STATE bp_message_write_line(MSG_SPI_PINS_STATE_str, 16)
+#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str), 16)
 void MSG_SPI_POLARITY_PROMPT_str(void);
-#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(MSG_SPI_POLARITY_PROMPT_str, 53)
+#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str), 53)
 void MSG_SPI_SAMPLE_PROMPT_str(void);
-#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(MSG_SPI_SAMPLE_PROMPT_str, 49)
+#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str), 49)
 void MSG_SPI_SPEED_PROMPT_str(void);
-#define MSG_SPI_SPEED_PROMPT bp_message_write_line(MSG_SPI_SPEED_PROMPT_str, 154)
+#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str), 154)
 void MSG_UART_MODE_IDENTIFIER_str(void);
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(MSG_UART_MODE_IDENTIFIER_str, 4)
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str), 4)
 void MSG_UART_PINS_STATE_str(void);
-#define MSG_UART_PINS_STATE bp_message_write_line(MSG_UART_PINS_STATE_str, 11)
+#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str), 11)
 void MSG_UART_POSSIBLE_OVERFLOW_str(void);
-#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(MSG_UART_POSSIBLE_OVERFLOW_str, 33)
+#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(__builtin_tbladdress(MSG_UART_POSSIBLE_OVERFLOW_str), 33)
 void MSG_UART_RESET_TO_EXIT_str(void);
-#define MSG_UART_RESET_TO_EXIT bp_message_write_line(MSG_UART_RESET_TO_EXIT_str, 13)
+#define MSG_UART_RESET_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_RESET_TO_EXIT_str), 13)
 void MSG_UNKNOWN_MACRO_ERROR_str(void);
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(MSG_UNKNOWN_MACRO_ERROR_str, 36)
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str), 36)
 void MSG_VREG_TOO_LOW_str(void);
-#define MSG_VREG_TOO_LOW bp_message_write_line(MSG_VREG_TOO_LOW_str, 31)
+#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str), 31)
 
 #endif /* BP_MESSAGES_V3_H */

--- a/Firmware/messages_v4.h
+++ b/Firmware/messages_v4.h
@@ -2,602 +2,602 @@
 #define BP_MESSAGES_V4_H
 
 void BPMSG1004_str(void);
-#define BPMSG1004 bp_message_write_line(BPMSG1004_str, 41)
+#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str), 41)
 void BPMSG1005_str(void);
-#define BPMSG1005 bp_message_write_buffer(BPMSG1005_str, 14)
+#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str), 14)
 void BPMSG1006_str(void);
-#define BPMSG1006 bp_message_write_line(BPMSG1006_str, 13)
+#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str), 13)
 void BPMSG1007_str(void);
-#define BPMSG1007 bp_message_write_line(BPMSG1007_str, 23)
+#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str), 23)
 void BPMSG1008_str(void);
-#define BPMSG1008 bp_message_write_buffer(BPMSG1008_str, 6)
+#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str), 6)
 void BPMSG1009_str(void);
-#define BPMSG1009 bp_message_write_line(BPMSG1009_str, 211)
+#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str), 211)
 void BPMSG1010_str(void);
-#define BPMSG1010 bp_message_write_line(BPMSG1010_str, 19)
+#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str), 19)
 void BPMSG1011_str(void);
-#define BPMSG1011 bp_message_write_line(BPMSG1011_str, 13)
+#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str), 13)
 void BPMSG1012_str(void);
-#define BPMSG1012 bp_message_write_line(BPMSG1012_str, 43)
+#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str), 43)
 void BPMSG1013_str(void);
-#define BPMSG1013 bp_message_write_buffer(BPMSG1013_str, 17)
+#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str), 17)
 void BPMSG1014_str(void);
-#define BPMSG1014 bp_message_write_line(BPMSG1014_str, 16)
+#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str), 16)
 void BPMSG1015_str(void);
-#define BPMSG1015 bp_message_write_line(BPMSG1015_str, 15)
+#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str), 15)
 void BPMSG1017_str(void);
-#define BPMSG1017 bp_message_write_buffer(BPMSG1017_str, 10)
+#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str), 10)
 void BPMSG1019_str(void);
-#define BPMSG1019 bp_message_write_buffer(BPMSG1019_str, 9)
+#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str), 9)
 void BPMSG1020_str(void);
-#define BPMSG1020 bp_message_write_buffer(BPMSG1020_str, 21)
+#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str), 21)
 void BPMSG1021_str(void);
-#define BPMSG1021 bp_message_write_buffer(BPMSG1021_str, 20)
+#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str), 20)
 void BPMSG1022_str(void);
-#define BPMSG1022 bp_message_write_buffer(BPMSG1022_str, 27)
+#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str), 27)
 void BPMSG1023_str(void);
-#define BPMSG1023 bp_message_write_buffer(BPMSG1023_str, 26)
+#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str), 26)
 void BPMSG1024_str(void);
-#define BPMSG1024 bp_message_write_buffer(BPMSG1024_str, 21)
+#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str), 21)
 void BPMSG1025_str(void);
-#define BPMSG1025 bp_message_write_buffer(BPMSG1025_str, 24)
+#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str), 24)
 void BPMSG1026_str(void);
-#define BPMSG1026 bp_message_write_buffer(BPMSG1026_str, 16)
+#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str), 16)
 void BPMSG1027_str(void);
-#define BPMSG1027 bp_message_write_buffer(BPMSG1027_str, 14)
+#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str), 14)
 void BPMSG1028_str(void);
-#define BPMSG1028 bp_message_write_line(BPMSG1028_str, 12)
+#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str), 12)
 void BPMSG1029_str(void);
-#define BPMSG1029 bp_message_write_line(BPMSG1029_str, 17)
+#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str), 17)
 void BPMSG1030_str(void);
-#define BPMSG1030 bp_message_write_buffer(BPMSG1030_str, 17)
+#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str), 17)
 void BPMSG1033_str(void);
-#define BPMSG1033 bp_message_write_buffer(BPMSG1033_str, 16)
+#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str), 16)
 void BPMSG1034_str(void);
-#define BPMSG1034 bp_message_write_line(BPMSG1034_str, 10)
+#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str), 10)
 void BPMSG1037_str(void);
-#define BPMSG1037 bp_message_write_line(BPMSG1037_str, 31)
+#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str), 31)
 void BPMSG1038_str(void);
-#define BPMSG1038 bp_message_write_buffer(BPMSG1038_str, 15)
+#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str), 15)
 void BPMSG1039_str(void);
-#define BPMSG1039 bp_message_write_buffer(BPMSG1039_str, 14)
+#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str), 14)
 void BPMSG1040_str(void);
-#define BPMSG1040 bp_message_write_line(BPMSG1040_str, 8)
+#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str), 8)
 void BPMSG1041_str(void);
-#define BPMSG1041 bp_message_write_line(BPMSG1041_str, 7)
+#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str), 7)
 void BPMSG1042_str(void);
-#define BPMSG1042 bp_message_write_line(BPMSG1042_str, 14)
+#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str), 14)
 void BPMSG1044_str(void);
-#define BPMSG1044 bp_message_write_buffer(BPMSG1044_str, 15)
+#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str), 15)
 void BPMSG1045_str(void);
-#define BPMSG1045 bp_message_write_buffer(BPMSG1045_str, 1)
+#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str), 1)
 void BPMSG1047_str(void);
-#define BPMSG1047 bp_message_write_buffer(BPMSG1047_str, 6)
+#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str), 6)
 void BPMSG1048_str(void);
-#define BPMSG1048 bp_message_write_buffer(BPMSG1048_str, 8)
+#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str), 8)
 void BPMSG1049_str(void);
-#define BPMSG1049 bp_message_write_buffer(BPMSG1049_str, 11)
+#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str), 11)
 void BPMSG1050_str(void);
-#define BPMSG1050 bp_message_write_line(BPMSG1050_str, 7)
+#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str), 7)
 void BPMSG1051_str(void);
-#define BPMSG1051 bp_message_write_line(BPMSG1051_str, 9)
+#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str), 9)
 void BPMSG1052_str(void);
-#define BPMSG1052 bp_message_write_line(BPMSG1052_str, 12)
+#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str), 12)
 void BPMSG1053_str(void);
-#define BPMSG1053 bp_message_write_line(BPMSG1053_str, 9)
+#define BPMSG1053 bp_message_write_line(__builtin_tbladdress(BPMSG1053_str), 9)
 void BPMSG1054_str(void);
-#define BPMSG1054 bp_message_write_buffer(BPMSG1054_str, 7)
+#define BPMSG1054 bp_message_write_buffer(__builtin_tbladdress(BPMSG1054_str), 7)
 void BPMSG1055_str(void);
-#define BPMSG1055 bp_message_write_line(BPMSG1055_str, 4)
+#define BPMSG1055 bp_message_write_line(__builtin_tbladdress(BPMSG1055_str), 4)
 void BPMSG1056_str(void);
-#define BPMSG1056 bp_message_write_buffer(BPMSG1056_str, 15)
+#define BPMSG1056 bp_message_write_buffer(__builtin_tbladdress(BPMSG1056_str), 15)
 void BPMSG1057_str(void);
-#define BPMSG1057 bp_message_write_line(BPMSG1057_str, 12)
+#define BPMSG1057 bp_message_write_line(__builtin_tbladdress(BPMSG1057_str), 12)
 void BPMSG1058_str(void);
-#define BPMSG1058 bp_message_write_buffer(BPMSG1058_str, 18)
+#define BPMSG1058 bp_message_write_buffer(__builtin_tbladdress(BPMSG1058_str), 18)
 void BPMSG1059_str(void);
-#define BPMSG1059 bp_message_write_line(BPMSG1059_str, 33)
+#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str), 33)
 void BPMSG1064_str(void);
-#define BPMSG1064 bp_message_write_line(BPMSG1064_str, 37)
+#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str), 37)
 void BPMSG1067_str(void);
-#define BPMSG1067 bp_message_write_buffer(BPMSG1067_str, 44)
+#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str), 44)
 void BPMSG1068_str(void);
-#define BPMSG1068 bp_message_write_buffer(BPMSG1068_str, 16)
+#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str), 16)
 void BPMSG1069_str(void);
-#define BPMSG1069 bp_message_write_buffer(BPMSG1069_str, 123)
+#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str), 123)
 void BPMSG1070_str(void);
-#define BPMSG1070 bp_message_write_line(BPMSG1070_str, 46)
+#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str), 46)
 void BPMSG1072_str(void);
-#define BPMSG1072 bp_message_write_line(BPMSG1072_str, 34)
+#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str), 34)
 void BPMSG1073_str(void);
-#define BPMSG1073 bp_message_write_line(BPMSG1073_str, 6)
+#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str), 6)
 void BPMSG1074_str(void);
-#define BPMSG1074 bp_message_write_buffer(BPMSG1074_str, 14)
+#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str), 14)
 void BPMSG1075_str(void);
-#define BPMSG1075 bp_message_write_buffer(BPMSG1075_str, 3)
+#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str), 3)
 void BPMSG1076_str(void);
-#define BPMSG1076 bp_message_write_line(BPMSG1076_str, 3)
+#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str), 3)
 void BPMSG1077_str(void);
-#define BPMSG1077 bp_message_write_line(BPMSG1077_str, 7)
+#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str), 7)
 void BPMSG1078_str(void);
-#define BPMSG1078 bp_message_write_line(BPMSG1078_str, 12)
+#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str), 12)
 void BPMSG1079_str(void);
-#define BPMSG1079 bp_message_write_line(BPMSG1079_str, 13)
+#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str), 13)
 void BPMSG1080_str(void);
-#define BPMSG1080 bp_message_write_buffer(BPMSG1080_str, 8)
+#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str), 8)
 void BPMSG1081_str(void);
-#define BPMSG1081 bp_message_write_buffer(BPMSG1081_str, 7)
+#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str), 7)
 void BPMSG1082_str(void);
-#define BPMSG1082 bp_message_write_line(BPMSG1082_str, 21)
+#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str), 21)
 void BPMSG1083_str(void);
-#define BPMSG1083 bp_message_write_line(BPMSG1083_str, 32)
+#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str), 32)
 void BPMSG1084_str(void);
-#define BPMSG1084 bp_message_write_buffer(BPMSG1084_str, 7)
+#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str), 7)
 void BPMSG1085_str(void);
-#define BPMSG1085 bp_message_write_line(BPMSG1085_str, 5)
+#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str), 5)
 void BPMSG1086_str(void);
-#define BPMSG1086 bp_message_write_line(BPMSG1086_str, 22)
+#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str), 22)
 void BPMSG1087_str(void);
-#define BPMSG1087 bp_message_write_line(BPMSG1087_str, 21)
+#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str), 21)
 void BPMSG1088_str(void);
-#define BPMSG1088 bp_message_write_line(BPMSG1088_str, 29)
+#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str), 29)
 void BPMSG1089_str(void);
-#define BPMSG1089 bp_message_write_buffer(BPMSG1089_str, 21)
+#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str), 21)
 void BPMSG1091_str(void);
-#define BPMSG1091 bp_message_write_buffer(BPMSG1091_str, 20)
+#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str), 20)
 void BPMSG1092_str(void);
-#define BPMSG1092 bp_message_write_line(BPMSG1092_str, 26)
+#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str), 26)
 void BPMSG1093_str(void);
-#define BPMSG1093 bp_message_write_line(BPMSG1093_str, 5)
+#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str), 5)
 void BPMSG1094_str(void);
-#define BPMSG1094 bp_message_write_line(BPMSG1094_str, 10)
+#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str), 10)
 void BPMSG1095_str(void);
-#define BPMSG1095 bp_message_write_buffer(BPMSG1095_str, 22)
+#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str), 22)
 void BPMSG1096_str(void);
-#define BPMSG1096 bp_message_write_buffer(BPMSG1096_str, 17)
+#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str), 17)
 void BPMSG1097_str(void);
-#define BPMSG1097 bp_message_write_buffer(BPMSG1097_str, 18)
+#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str), 18)
 void BPMSG1098_str(void);
-#define BPMSG1098 bp_message_write_buffer(BPMSG1098_str, 12)
+#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str), 12)
 void BPMSG1099_str(void);
-#define BPMSG1099 bp_message_write_buffer(BPMSG1099_str, 6)
+#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str), 6)
 void BPMSG1100_str(void);
-#define BPMSG1100 bp_message_write_line(BPMSG1100_str, 2)
+#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str), 2)
 void BPMSG1101_str(void);
-#define BPMSG1101 bp_message_write_buffer(BPMSG1101_str, 7)
+#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str), 7)
 void BPMSG1102_str(void);
-#define BPMSG1102 bp_message_write_buffer(BPMSG1102_str, 6)
+#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str), 6)
 void BPMSG1103_str(void);
-#define BPMSG1103 bp_message_write_line(BPMSG1103_str, 8)
+#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str), 8)
 void BPMSG1104_str(void);
-#define BPMSG1104 bp_message_write_line(BPMSG1104_str, 8)
+#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str), 8)
 void BPMSG1105_str(void);
-#define BPMSG1105 bp_message_write_line(BPMSG1105_str, 14)
+#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str), 14)
 void BPMSG1106_str(void);
-#define BPMSG1106 bp_message_write_line(BPMSG1106_str, 14)
+#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str), 14)
 void BPMSG1107_str(void);
-#define BPMSG1107 bp_message_write_line(BPMSG1107_str, 16)
+#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str), 16)
 void BPMSG1108_str(void);
-#define BPMSG1108 bp_message_write_buffer(BPMSG1108_str, 13)
+#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str), 13)
 void BPMSG1109_str(void);
-#define BPMSG1109 bp_message_write_buffer(BPMSG1109_str, 10)
+#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str), 10)
 void BPMSG1110_str(void);
-#define BPMSG1110 bp_message_write_buffer(BPMSG1110_str, 21)
+#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str), 21)
 void BPMSG1111_str(void);
-#define BPMSG1111 bp_message_write_line(BPMSG1111_str, 23)
+#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str), 23)
 void BPMSG1112_str(void);
-#define BPMSG1112 bp_message_write_line(BPMSG1112_str, 14)
+#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str), 14)
 void BPMSG1114_str(void);
-#define BPMSG1114 bp_message_write_line(BPMSG1114_str, 21)
+#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str), 21)
 void BPMSG1115_str(void);
-#define BPMSG1115 bp_message_write_line(BPMSG1115_str, 7)
+#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str), 7)
 void BPMSG1117_str(void);
-#define BPMSG1117 bp_message_write_buffer(BPMSG1117_str, 6)
+#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str), 6)
 void BPMSG1118_str(void);
-#define BPMSG1118 bp_message_write_line(BPMSG1118_str, 30)
+#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str), 30)
 void BPMSG1119_str(void);
-#define BPMSG1119 bp_message_write_line(BPMSG1119_str, 12)
+#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str), 12)
 void BPMSG1120_str(void);
-#define BPMSG1120 bp_message_write_line(BPMSG1120_str, 34)
+#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str), 34)
 void BPMSG1121_str(void);
-#define BPMSG1121 bp_message_write_line(BPMSG1121_str, 30)
+#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str), 30)
 void BPMSG1123_str(void);
-#define BPMSG1123 bp_message_write_buffer(BPMSG1123_str, 27)
+#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str), 27)
 void BPMSG1124_str(void);
-#define BPMSG1124 bp_message_write_buffer(BPMSG1124_str, 28)
+#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str), 28)
 void BPMSG1127_str(void);
-#define BPMSG1127 bp_message_write_line(BPMSG1127_str, 34)
+#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str), 34)
 void BPMSG1128_str(void);
-#define BPMSG1128 bp_message_write_line(BPMSG1128_str, 18)
+#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str), 18)
 void BPMSG1133_str(void);
-#define BPMSG1133 bp_message_write_line(BPMSG1133_str, 190)
+#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str), 190)
 void BPMSG1134_str(void);
-#define BPMSG1134 bp_message_write_line(BPMSG1134_str, 20)
+#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str), 20)
 void BPMSG1135_str(void);
-#define BPMSG1135 bp_message_write_buffer(BPMSG1135_str, 14)
+#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str), 14)
 void BPMSG1136_str(void);
-#define BPMSG1136 bp_message_write_buffer(BPMSG1136_str, 5)
+#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str), 5)
 void BPMSG1137_str(void);
-#define BPMSG1137 bp_message_write_buffer(BPMSG1137_str, 6)
+#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str), 6)
 void BPMSG1163_str(void);
-#define BPMSG1163 bp_message_write_line(BPMSG1163_str, 46)
+#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str), 46)
 void BPMSG1164_str(void);
-#define BPMSG1164 bp_message_write_line(BPMSG1164_str, 4)
+#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str), 4)
 void BPMSG1165_str(void);
-#define BPMSG1165 bp_message_write_buffer(BPMSG1165_str, 3)
+#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str), 3)
 void BPMSG1166_str(void);
-#define BPMSG1166 bp_message_write_buffer(BPMSG1166_str, 8)
+#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str), 8)
 void BPMSG1167_str(void);
-#define BPMSG1167 bp_message_write_buffer(BPMSG1167_str, 8)
+#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str), 8)
 void BPMSG1168_str(void);
-#define BPMSG1168 bp_message_write_buffer(BPMSG1168_str, 8)
+#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str), 8)
 void BPMSG1169_str(void);
-#define BPMSG1169 bp_message_write_buffer(BPMSG1169_str, 4)
+#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str), 4)
 void BPMSG1170_str(void);
-#define BPMSG1170 bp_message_write_line(BPMSG1170_str, 14)
+#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str), 14)
 void BPMSG1171_str(void);
-#define BPMSG1171 bp_message_write_buffer(BPMSG1171_str, 2)
+#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str), 2)
 void BPMSG1172_str(void);
-#define BPMSG1172 bp_message_write_buffer(BPMSG1172_str, 3)
+#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str), 3)
 void BPMSG1173_str(void);
-#define BPMSG1173 bp_message_write_buffer(BPMSG1173_str, 4)
+#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str), 4)
 void BPMSG1174_str(void);
-#define BPMSG1174 bp_message_write_buffer(BPMSG1174_str, 3)
+#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str), 3)
 void BPMSG1175_str(void);
-#define BPMSG1175 bp_message_write_line(BPMSG1175_str, 8)
+#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str), 8)
 void BPMSG1176_str(void);
-#define BPMSG1176 bp_message_write_line(BPMSG1176_str, 10)
+#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str), 10)
 void BPMSG1177_str(void);
-#define BPMSG1177 bp_message_write_line(BPMSG1177_str, 10)
+#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str), 10)
 void BPMSG1178_str(void);
-#define BPMSG1178 bp_message_write_line(BPMSG1178_str, 38)
+#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str), 38)
 void BPMSG1179_str(void);
-#define BPMSG1179 bp_message_write_buffer(BPMSG1179_str, 6)
+#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str), 6)
 void BPMSG1180_str(void);
-#define BPMSG1180 bp_message_write_line(BPMSG1180_str, 8)
+#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str), 8)
 void BPMSG1181_str(void);
-#define BPMSG1181 bp_message_write_buffer(BPMSG1181_str, 4)
+#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str), 4)
 void BPMSG1182_str(void);
-#define BPMSG1182 bp_message_write_buffer(BPMSG1182_str, 3)
+#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str), 3)
 void BPMSG1183_str(void);
-#define BPMSG1183 bp_message_write_buffer(BPMSG1183_str, 4)
+#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str), 4)
 void BPMSG1184_str(void);
-#define BPMSG1184 bp_message_write_buffer(BPMSG1184_str, 2)
+#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str), 2)
 void BPMSG1185_str(void);
-#define BPMSG1185 bp_message_write_line(BPMSG1185_str, 3)
+#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str), 3)
 void BPMSG1186_str(void);
-#define BPMSG1186 bp_message_write_line(BPMSG1186_str, 5)
+#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str), 5)
 void BPMSG1194_str(void);
-#define BPMSG1194 bp_message_write_buffer(BPMSG1194_str, 3)
+#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str), 3)
 void BPMSG1195_str(void);
-#define BPMSG1195 bp_message_write_buffer(BPMSG1195_str, 3)
+#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str), 3)
 void BPMSG1196_str(void);
-#define BPMSG1196 bp_message_write_buffer(BPMSG1196_str, 15)
+#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str), 15)
 void BPMSG1197_str(void);
-#define BPMSG1197 bp_message_write_buffer(BPMSG1197_str, 15)
+#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str), 15)
 void BPMSG1199_str(void);
-#define BPMSG1199 bp_message_write_buffer(BPMSG1199_str, 84)
+#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str), 84)
 void BPMSG1200_str(void);
-#define BPMSG1200 bp_message_write_buffer(BPMSG1200_str, 33)
+#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str), 33)
 void BPMSG1201_str(void);
-#define BPMSG1201 bp_message_write_buffer(BPMSG1201_str, 50)
+#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str), 50)
 void BPMSG1202_str(void);
-#define BPMSG1202 bp_message_write_buffer(BPMSG1202_str, 32)
+#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str), 32)
 void BPMSG1203_str(void);
-#define BPMSG1203 bp_message_write_buffer(BPMSG1203_str, 124)
+#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str), 124)
 void BPMSG1204_str(void);
-#define BPMSG1204 bp_message_write_line(BPMSG1204_str, 11)
+#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str), 11)
 void BPMSG1206_str(void);
-#define BPMSG1206 bp_message_write_line(BPMSG1206_str, 14)
+#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str), 14)
 void BPMSG1207_str(void);
-#define BPMSG1207 bp_message_write_line(BPMSG1207_str, 28)
+#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str), 28)
 void BPMSG1208_str(void);
-#define BPMSG1208 bp_message_write_line(BPMSG1208_str, 20)
+#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str), 20)
 void BPMSG1209_str(void);
-#define BPMSG1209 bp_message_write_line(BPMSG1209_str, 34)
+#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str), 34)
 void BPMSG1210_str(void);
-#define BPMSG1210 bp_message_write_buffer(BPMSG1210_str, 7)
+#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str), 7)
 void BPMSG1211_str(void);
-#define BPMSG1211 bp_message_write_line(BPMSG1211_str, 27)
+#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str), 27)
 void BPMSG1212_str(void);
-#define BPMSG1212 bp_message_write_line(BPMSG1212_str, 2)
+#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str), 2)
 void BPMSG1213_str(void);
-#define BPMSG1213 bp_message_write_line(BPMSG1213_str, 20)
+#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str), 20)
 void BPMSG1214_str(void);
-#define BPMSG1214 bp_message_write_line(BPMSG1214_str, 18)
+#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str), 18)
 void BPMSG1216_str(void);
-#define BPMSG1216 bp_message_write_line(BPMSG1216_str, 29)
+#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str), 29)
 void BPMSG1219_str(void);
-#define BPMSG1219 bp_message_write_line(BPMSG1219_str, 152)
+#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str), 152)
 void BPMSG1220_str(void);
-#define BPMSG1220 bp_message_write_line(BPMSG1220_str, 36)
+#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str), 36)
 void BPMSG1221_str(void);
-#define BPMSG1221 bp_message_write_line(BPMSG1221_str, 4)
+#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str), 4)
 void BPMSG1222_str(void);
-#define BPMSG1222 bp_message_write_line(BPMSG1222_str, 5)
+#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str), 5)
 void BPMSG1223_str(void);
-#define BPMSG1223 bp_message_write_line(BPMSG1223_str, 10)
+#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str), 10)
 void BPMSG1226_str(void);
-#define BPMSG1226 bp_message_write_line(BPMSG1226_str, 10)
+#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str), 10)
 void BPMSG1228_str(void);
-#define BPMSG1228 bp_message_write_buffer(BPMSG1228_str, 10)
+#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str), 10)
 void BPMSG1234_str(void);
-#define BPMSG1234 bp_message_write_buffer(BPMSG1234_str, 4)
+#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str), 4)
 void BPMSG1237_str(void);
-#define BPMSG1237 bp_message_write_buffer(BPMSG1237_str, 8)
+#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str), 8)
 void BPMSG1238_str(void);
-#define BPMSG1238 bp_message_write_line(BPMSG1238_str, 38)
+#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str), 38)
 void BPMSG1239_str(void);
-#define BPMSG1239 bp_message_write_line(BPMSG1239_str, 28)
+#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str), 28)
 void BPMSG1240_str(void);
-#define BPMSG1240 bp_message_write_line(BPMSG1240_str, 16)
+#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str), 16)
 void BPMSG1241_str(void);
-#define BPMSG1241 bp_message_write_line(BPMSG1241_str, 14)
+#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str), 14)
 void BPMSG1242_str(void);
-#define BPMSG1242 bp_message_write_line(BPMSG1242_str, 15)
+#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str), 15)
 void BPMSG1243_str(void);
-#define BPMSG1243 bp_message_write_line(BPMSG1243_str, 5)
+#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str), 5)
 void BPMSG1244_str(void);
-#define BPMSG1244 bp_message_write_line(BPMSG1244_str, 14)
+#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str), 14)
 void BPMSG1245_str(void);
-#define BPMSG1245 bp_message_write_buffer(BPMSG1245_str, 11)
+#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str), 11)
 void BPMSG1248_str(void);
-#define BPMSG1248 bp_message_write_line(BPMSG1248_str, 25)
+#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str), 25)
 void BPMSG1251_str(void);
-#define BPMSG1251 bp_message_write_line(BPMSG1251_str, 17)
+#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str), 17)
 void BPMSG1252_str(void);
-#define BPMSG1252 bp_message_write_buffer(BPMSG1252_str, 27)
+#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str), 27)
 void BPMSG1254_str(void);
-#define BPMSG1254 bp_message_write_line(BPMSG1254_str, 19)
+#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str), 19)
 void BPMSG1255_str(void);
-#define BPMSG1255 bp_message_write_line(BPMSG1255_str, 12)
+#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str), 12)
 void BPMSG1256_str(void);
-#define BPMSG1256 bp_message_write_line(BPMSG1256_str, 86)
+#define BPMSG1256 bp_message_write_line(__builtin_tbladdress(BPMSG1256_str), 86)
 void BPMSG1257_str(void);
-#define BPMSG1257 bp_message_write_buffer(BPMSG1257_str, 36)
+#define BPMSG1257 bp_message_write_buffer(__builtin_tbladdress(BPMSG1257_str), 36)
 void BPMSG1259_str(void);
-#define BPMSG1259 bp_message_write_line(BPMSG1259_str, 9)
+#define BPMSG1259 bp_message_write_line(__builtin_tbladdress(BPMSG1259_str), 9)
 void BPMSG1262_str(void);
-#define BPMSG1262 bp_message_write_line(BPMSG1262_str, 11)
+#define BPMSG1262 bp_message_write_line(__builtin_tbladdress(BPMSG1262_str), 11)
 void BPMSG1263_str(void);
-#define BPMSG1263 bp_message_write_line(BPMSG1263_str, 23)
+#define BPMSG1263 bp_message_write_line(__builtin_tbladdress(BPMSG1263_str), 23)
 void BPMSG1264_str(void);
-#define BPMSG1264 bp_message_write_line(BPMSG1264_str, 23)
+#define BPMSG1264 bp_message_write_line(__builtin_tbladdress(BPMSG1264_str), 23)
 void BPMSG1265_str(void);
-#define BPMSG1265 bp_message_write_line(BPMSG1265_str, 6)
+#define BPMSG1265 bp_message_write_line(__builtin_tbladdress(BPMSG1265_str), 6)
 void BPMSG1266_str(void);
-#define BPMSG1266 bp_message_write_buffer(BPMSG1266_str, 3)
+#define BPMSG1266 bp_message_write_buffer(__builtin_tbladdress(BPMSG1266_str), 3)
 void BPMSG1267_str(void);
-#define BPMSG1267 bp_message_write_buffer(BPMSG1267_str, 3)
+#define BPMSG1267 bp_message_write_buffer(__builtin_tbladdress(BPMSG1267_str), 3)
 void BPMSG1268_str(void);
-#define BPMSG1268 bp_message_write_buffer(BPMSG1268_str, 2)
+#define BPMSG1268 bp_message_write_buffer(__builtin_tbladdress(BPMSG1268_str), 2)
 void BPMSG1269_str(void);
-#define BPMSG1269 bp_message_write_buffer(BPMSG1269_str, 10)
+#define BPMSG1269 bp_message_write_buffer(__builtin_tbladdress(BPMSG1269_str), 10)
 void BPMSG1270_str(void);
-#define BPMSG1270 bp_message_write_buffer(BPMSG1270_str, 4)
+#define BPMSG1270 bp_message_write_buffer(__builtin_tbladdress(BPMSG1270_str), 4)
 void BPMSG1271_str(void);
-#define BPMSG1271 bp_message_write_line(BPMSG1271_str, 87)
+#define BPMSG1271 bp_message_write_line(__builtin_tbladdress(BPMSG1271_str), 87)
 void BPMSG1272_str(void);
-#define BPMSG1272 bp_message_write_buffer(BPMSG1272_str, 25)
+#define BPMSG1272 bp_message_write_buffer(__builtin_tbladdress(BPMSG1272_str), 25)
 void BPMSG1273_str(void);
-#define BPMSG1273 bp_message_write_line(BPMSG1273_str, 7)
+#define BPMSG1273 bp_message_write_line(__builtin_tbladdress(BPMSG1273_str), 7)
 void BPMSG1274_str(void);
-#define BPMSG1274 bp_message_write_line(BPMSG1274_str, 8)
+#define BPMSG1274 bp_message_write_line(__builtin_tbladdress(BPMSG1274_str), 8)
 void BPMSG1280_str(void);
-#define BPMSG1280 bp_message_write_line(BPMSG1280_str, 19)
+#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str), 19)
 void BPMSG1281_str(void);
-#define BPMSG1281 bp_message_write_line(BPMSG1281_str, 14)
+#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str), 14)
 void BPMSG1282_str(void);
-#define BPMSG1282 bp_message_write_line(BPMSG1282_str, 56)
+#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str), 56)
 void BPMSG1283_str(void);
-#define BPMSG1283 bp_message_write_buffer(BPMSG1283_str, 15)
+#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str), 15)
 void BPMSG1284_str(void);
-#define BPMSG1284 bp_message_write_buffer(BPMSG1284_str, 15)
+#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str), 15)
 void BPMSG1285_str(void);
-#define BPMSG1285 bp_message_write_line(BPMSG1285_str, 4)
+#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str), 4)
 void HLP1000_str(void);
-#define HLP1000 bp_message_write_line(HLP1000_str, 32)
+#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str), 32)
 void HLP1001_str(void);
-#define HLP1001 bp_message_write_line(HLP1001_str, 75)
+#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str), 75)
 void HLP1002_str(void);
-#define HLP1002 bp_message_write_line(HLP1002_str, 37)
+#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str), 37)
 void HLP1003_str(void);
-#define HLP1003 bp_message_write_line(HLP1003_str, 39)
+#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str), 39)
 void HLP1004_str(void);
-#define HLP1004 bp_message_write_line(HLP1004_str, 20)
+#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str), 20)
 void HLP1005_str(void);
-#define HLP1005 bp_message_write_line(HLP1005_str, 26)
+#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str), 26)
 void HLP1006_str(void);
-#define HLP1006 bp_message_write_line(HLP1006_str, 39)
+#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str), 39)
 void HLP1007_str(void);
-#define HLP1007 bp_message_write_line(HLP1007_str, 26)
+#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str), 26)
 void HLP1008_str(void);
-#define HLP1008 bp_message_write_line(HLP1008_str, 45)
+#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str), 45)
 void HLP1009_str(void);
-#define HLP1009 bp_message_write_line(HLP1009_str, 39)
+#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str), 39)
 void HLP1010_str(void);
-#define HLP1010 bp_message_write_line(HLP1010_str, 57)
+#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str), 57)
 void HLP1011_str(void);
-#define HLP1011 bp_message_write_line(HLP1011_str, 52)
+#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str), 52)
 void HLP1012_str(void);
-#define HLP1012 bp_message_write_line(HLP1012_str, 27)
+#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str), 27)
 void HLP1013_str(void);
-#define HLP1013 bp_message_write_line(HLP1013_str, 32)
+#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str), 32)
 void HLP1014_str(void);
-#define HLP1014 bp_message_write_line(HLP1014_str, 27)
+#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str), 27)
 void HLP1015_str(void);
-#define HLP1015 bp_message_write_line(HLP1015_str, 36)
+#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str), 36)
 void HLP1016_str(void);
-#define HLP1016 bp_message_write_line(HLP1016_str, 32)
+#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str), 32)
 void HLP1017_str(void);
-#define HLP1017 bp_message_write_line(HLP1017_str, 24)
+#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str), 24)
 void HLP1018_str(void);
-#define HLP1018 bp_message_write_line(HLP1018_str, 31)
+#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str), 31)
 void HLP1019_str(void);
-#define HLP1019 bp_message_write_line(HLP1019_str, 40)
+#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str), 40)
 void HLP1020_str(void);
-#define HLP1020 bp_message_write_line(HLP1020_str, 36)
+#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str), 36)
 void HLP1021_str(void);
-#define HLP1021 bp_message_write_line(HLP1021_str, 53)
+#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str), 53)
 void HLP1022_str(void);
-#define HLP1022 bp_message_write_line(HLP1022_str, 61)
+#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str), 61)
 void MSG_1WIRE_MODE_IDENTIFIER_str(void);
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(MSG_1WIRE_MODE_IDENTIFIER_str, 4)
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str), 4)
 void MSG_1WIRE_NEXT_CLOCK_ALERT_str(void);
-#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(MSG_1WIRE_NEXT_CLOCK_ALERT_str, 36)
+#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str), 36)
 void MSG_1WIRE_SPEED_PROMPT_str(void);
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(MSG_1WIRE_SPEED_PROMPT_str, 62)
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str), 62)
 void MSG_ACK_str(void);
-#define MSG_ACK bp_message_write_buffer(MSG_ACK_str, 3)
+#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str), 3)
 void MSG_ANY_KEY_TO_EXIT_PROMPT_str(void);
-#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(MSG_ANY_KEY_TO_EXIT_PROMPT_str, 15)
+#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str), 15)
 void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(MSG_BASE_CONVERTER_EQUAL_SIGN_str, 3)
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str), 3)
 void MSG_BAUD_DETECTION_SELECTED_str(void);
-#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(MSG_BAUD_DETECTION_SELECTED_str, 25)
+#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(__builtin_tbladdress(MSG_BAUD_DETECTION_SELECTED_str), 25)
 void MSG_BBIO_MODE_IDENTIFIER_str(void);
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(MSG_BBIO_MODE_IDENTIFIER_str, 5)
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str), 5)
 void MSG_BINARY_NUMBER_PREFIX_str(void);
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(MSG_BINARY_NUMBER_PREFIX_str, 2)
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str), 2)
 void MSG_CFG0_FIELD_str(void);
-#define MSG_CFG0_FIELD bp_message_write_buffer(MSG_CFG0_FIELD_str, 6)
+#define MSG_CFG0_FIELD bp_message_write_buffer(__builtin_tbladdress(MSG_CFG0_FIELD_str), 6)
 void MSG_CHIP_REVISION_A3_str(void);
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(MSG_CHIP_REVISION_A3_str, 2)
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str), 2)
 void MSG_CHIP_REVISION_A5_str(void);
-#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(MSG_CHIP_REVISION_A5_str, 2)
+#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A5_str), 2)
 void MSG_CHIP_REVISION_ID_BEGIN_str(void);
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(MSG_CHIP_REVISION_ID_BEGIN_str, 15)
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str), 15)
 void MSG_CHIP_REVISION_UNKNOWN_str(void);
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(MSG_CHIP_REVISION_UNKNOWN_str, 3)
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str), 3)
 void MSG_CLUTCH_DISENGAGED_str(void);
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(MSG_CLUTCH_DISENGAGED_str, 20)
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str), 20)
 void MSG_CLUTCH_ENGAGED_str(void);
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(MSG_CLUTCH_ENGAGED_str, 17)
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str), 17)
 void MSG_FINISH_SETUP_PROMPT_str(void);
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(MSG_FINISH_SETUP_PROMPT_str, 61)
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str), 61)
 void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(MSG_HEXADECIMAL_NUMBER_PREFIX_str, 2)
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str), 2)
 void MSG_I2C_MODE_IDENTIFIER_str(void);
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(MSG_I2C_MODE_IDENTIFIER_str, 4)
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str), 4)
 void MSG_I2C_PINS_STATE_str(void);
-#define MSG_I2C_PINS_STATE bp_message_write_line(MSG_I2C_PINS_STATE_str, 11)
+#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str), 11)
 void MSG_I2C_READ_ADDRESS_END_str(void);
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(MSG_I2C_READ_ADDRESS_END_str, 4)
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str), 4)
 void MSG_I2C_START_BIT_str(void);
-#define MSG_I2C_START_BIT bp_message_write_line(MSG_I2C_START_BIT_str, 13)
+#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str), 13)
 void MSG_I2C_STOP_BIT_str(void);
-#define MSG_I2C_STOP_BIT bp_message_write_line(MSG_I2C_STOP_BIT_str, 12)
+#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str), 12)
 void MSG_I2C_WRITE_ADDRESS_END_str(void);
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(MSG_I2C_WRITE_ADDRESS_END_str, 4)
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str), 4)
 void MSG_MODE_HEADER_END_str(void);
-#define MSG_MODE_HEADER_END bp_message_write_line(MSG_MODE_HEADER_END_str, 2)
+#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str), 2)
 void MSG_NACK_str(void);
-#define MSG_NACK bp_message_write_buffer(MSG_NACK_str, 4)
+#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str), 4)
 void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str, 34)
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str), 34)
 void MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str(void);
-#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str, 38)
+#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str), 38)
 void MSG_PIC_MODE_IDENTIFIER_str(void);
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(MSG_PIC_MODE_IDENTIFIER_str, 4)
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str), 4)
 void MSG_PIC_UNKNOWN_MODE_str(void);
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(MSG_PIC_UNKNOWN_MODE_str, 12)
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str), 12)
 void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(MSG_PIN_OUTPUT_TYPE_PROMPT_str, 79)
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str), 79)
 void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(MSG_PWM_FREQUENCY_TOO_LOW_str, 36)
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str), 36)
 void MSG_PWM_HZ_MARKER_str(void);
-#define MSG_PWM_HZ_MARKER bp_message_write_line(MSG_PWM_HZ_MARKER_str, 3)
+#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str), 3)
 void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str, 12)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str), 12)
 void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str, 13)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str), 13)
 void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str, 25)
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str), 25)
 void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str, 10)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str), 10)
 void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str, 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str), 6)
 void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str, 7)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str), 7)
 void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str, 11)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str), 11)
 void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str, 6)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str), 6)
 void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str, 15)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str), 15)
 void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(MSG_RAW2WIRE_ATR_REPLY_HEADER_str, 45)
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str), 45)
 void MSG_RAW2WIRE_ATR_RFU_str(void);
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(MSG_RAW2WIRE_ATR_RFU_str, 3)
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str), 3)
 void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str, 63)
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str), 63)
 void MSG_RAW2WIRE_I2C_START_str(void);
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(MSG_RAW2WIRE_I2C_START_str, 8)
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str), 8)
 void MSG_RAW2WIRE_I2C_STOP_str(void);
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(MSG_RAW2WIRE_I2C_STOP_str, 6)
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str), 6)
 void MSG_RAW2WIRE_MACRO_MENU_str(void);
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(MSG_RAW2WIRE_MACRO_MENU_str, 56)
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str), 56)
 void MSG_RAW2WIRE_MODE_HEADER_str(void);
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW2WIRE_MODE_HEADER_str, 16)
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str), 16)
 void MSG_RAW3WIRE_MODE_HEADER_str(void);
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(MSG_RAW3WIRE_MODE_HEADER_str, 20)
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str), 20)
 void MSG_RAW_BRG_VALUE_INPUT_str(void);
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(MSG_RAW_BRG_VALUE_INPUT_str, 23)
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str), 23)
 void MSG_RAW_MODE_IDENTIFIER_str(void);
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(MSG_RAW_MODE_IDENTIFIER_str, 4)
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str), 4)
 void MSG_RESET_MESSAGE_str(void);
-#define MSG_RESET_MESSAGE bp_message_write_line(MSG_RESET_MESSAGE_str, 5)
+#define MSG_RESET_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_RESET_MESSAGE_str), 5)
 void MSG_SNIFFER_MESSAGE_str(void);
-#define MSG_SNIFFER_MESSAGE bp_message_write_line(MSG_SNIFFER_MESSAGE_str, 7)
+#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str), 7)
 void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(MSG_SOFTWARE_MODE_SPEED_PROMPT_str, 59)
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str), 59)
 void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(MSG_SPI_COULD_NOT_KEEP_UP_str, 16)
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str), 16)
 void MSG_SPI_CS_DISABLED_str(void);
-#define MSG_SPI_CS_DISABLED bp_message_write_line(MSG_SPI_CS_DISABLED_str, 11)
+#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str), 11)
 void MSG_SPI_CS_ENABLED_str(void);
-#define MSG_SPI_CS_ENABLED bp_message_write_line(MSG_SPI_CS_ENABLED_str, 10)
+#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str), 10)
 void MSG_SPI_CS_MODE_PROMPT_str(void);
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(MSG_SPI_CS_MODE_PROMPT_str, 29)
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str), 29)
 void MSG_SPI_EDGE_PROMPT_str(void);
-#define MSG_SPI_EDGE_PROMPT bp_message_write_line(MSG_SPI_EDGE_PROMPT_str, 67)
+#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str), 67)
 void MSG_SPI_MACRO_MENU_str(void);
-#define MSG_SPI_MACRO_MENU bp_message_write_line(MSG_SPI_MACRO_MENU_str, 206)
+#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str), 206)
 void MSG_SPI_MODE_HEADER_START_str(void);
-#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(MSG_SPI_MODE_HEADER_START_str, 32)
+#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str), 32)
 void MSG_SPI_MODE_IDENTIFIER_str(void);
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(MSG_SPI_MODE_IDENTIFIER_str, 4)
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str), 4)
 void MSG_SPI_PINS_STATE_str(void);
-#define MSG_SPI_PINS_STATE bp_message_write_line(MSG_SPI_PINS_STATE_str, 16)
+#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str), 16)
 void MSG_SPI_POLARITY_PROMPT_str(void);
-#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(MSG_SPI_POLARITY_PROMPT_str, 53)
+#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str), 53)
 void MSG_SPI_SAMPLE_PROMPT_str(void);
-#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(MSG_SPI_SAMPLE_PROMPT_str, 49)
+#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str), 49)
 void MSG_SPI_SPEED_PROMPT_str(void);
-#define MSG_SPI_SPEED_PROMPT bp_message_write_line(MSG_SPI_SPEED_PROMPT_str, 154)
+#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str), 154)
 void MSG_UART_MODE_IDENTIFIER_str(void);
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(MSG_UART_MODE_IDENTIFIER_str, 4)
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str), 4)
 void MSG_UART_NORMAL_TO_EXIT_str(void);
-#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(MSG_UART_NORMAL_TO_EXIT_str, 14)
+#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_NORMAL_TO_EXIT_str), 14)
 void MSG_UART_PINS_STATE_str(void);
-#define MSG_UART_PINS_STATE bp_message_write_line(MSG_UART_PINS_STATE_str, 11)
+#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str), 11)
 void MSG_UNKNOWN_MACRO_ERROR_str(void);
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(MSG_UNKNOWN_MACRO_ERROR_str, 36)
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str), 36)
 void MSG_USING_ONBOARD_I2C_EEPROM_str(void);
-#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(MSG_USING_ONBOARD_I2C_EEPROM_str, 39)
+#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(__builtin_tbladdress(MSG_USING_ONBOARD_I2C_EEPROM_str), 39)
 void MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str(void);
-#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str, 41)
+#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(__builtin_tbladdress(MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str), 41)
 void MSG_VPU_3V3_MARKER_str(void);
-#define MSG_VPU_3V3_MARKER bp_message_write_buffer(MSG_VPU_3V3_MARKER_str, 9)
+#define MSG_VPU_3V3_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_3V3_MARKER_str), 9)
 void MSG_VPU_5V_MARKER_str(void);
-#define MSG_VPU_5V_MARKER bp_message_write_buffer(MSG_VPU_5V_MARKER_str, 8)
+#define MSG_VPU_5V_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_5V_MARKER_str), 8)
 void MSG_VREG_TOO_LOW_str(void);
-#define MSG_VREG_TOO_LOW bp_message_write_line(MSG_VREG_TOO_LOW_str, 31)
+#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str), 31)
 void MSG_XSV1_MODE_IDENTIFIER_str(void);
-#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(MSG_XSV1_MODE_IDENTIFIER_str, 4)
+#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_XSV1_MODE_IDENTIFIER_str), 4)
 
 #endif /* BP_MESSAGES_V4_H */

--- a/tools/packstrings/packstrings.py
+++ b/tools/packstrings/packstrings.py
@@ -76,7 +76,7 @@ with open(args.outbase + '.h', 'w') as header_output:
     for row in sorted(lines):
         call = BUFFER_WRITE_CALL if row[1] == '0' else LINE_WRITE_CALL
         header_output.write('void %s_str(void);\n' % row[0])
-        header_output.write('#define %s %s(%s_str, %d)\n' %
+        header_output.write('#define %s %s(__builtin_tbladdress(%s_str), %d)\n' %
                             (row[0], call, row[0], len(row[2])))
         offset += len(row[2])
 


### PR DESCRIPTION
On parts with more than 64KiB flash, function pointers are implemented
using 16-bit "handles". Use __builtin_tbladdress() to pass the full
address to the message printing functions.

Remove unnecessary index arithmetic from bp_message_write_buffer().

Fixes #61.