### PR TITLE
Use null-terminated strings

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -18,36 +18,44 @@
 
 #include "base.h"
 
-void bp_message_write_buffer(unsigned long strptr, size_t length) {
-    size_t index;
+void bp_message_write_buffer(unsigned long strptr) {
     unsigned char tblpag_prev = TBLPAG;
+    unsigned char index = 0;
+    char ch;
 
-    for (index = 0; index < length; index++) {
+    while (1) {
         TBLPAG = (strptr >> 16) & 0xFF;
-        switch (index % 3) {
+        switch (index) {
             case 0:
-                UART1TX(__builtin_tblrdl(strptr) & 0xFF);
+                ch = __builtin_tblrdl(strptr) & 0xFF;
+                index++;
                 break;
 
             case 1:
-                UART1TX((__builtin_tblrdl(strptr) >> 8) & 0xFF);
+                ch = (__builtin_tblrdl(strptr) >> 8) & 0xFF;
+                index++;
                 break;
 
             case 2:
-                UART1TX(__builtin_tblrdh(strptr) & 0xFF);
+                ch = __builtin_tblrdh(strptr) & 0xFF;
                 strptr += 2;
+                index = 0;
                 break;
+        }
 
-            default:
-                break;
+        if (ch != '\0') {
+            UART1TX(ch);
+        }
+        else {
+            break;
         }
     }
 
     TBLPAG = tblpag_prev;
 }
 
-void bp_message_write_line(unsigned long strptr, size_t length) {
-    bp_message_write_buffer(strptr, length);
+void bp_message_write_line(unsigned long strptr) {
+    bp_message_write_buffer(strptr);
     bpBR;
 }
 

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -19,11 +19,11 @@
 #include "base.h"
 
 void bp_message_write_buffer(unsigned long strptr) {
-    unsigned char tblpag_prev = TBLPAG;
-    unsigned char index = 0;
+    uint8_t tblpag_prev = TBLPAG;
+    uint8_t index = 0;
     char ch;
 
-    while (1) {
+    do {
         TBLPAG = (strptr >> 16) & 0xFF;
         switch (index) {
             case 0:
@@ -46,10 +46,7 @@ void bp_message_write_buffer(unsigned long strptr) {
         if (ch != '\0') {
             UART1TX(ch);
         }
-        else {
-            break;
-        }
-    }
+    } while(ch != '\0');
 
     TBLPAG = tblpag_prev;
 }

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -39,8 +39,7 @@ void print_help(void);
  * Prints a given byte array range from the packed string buffer to the serial
  * port.
  * 
- * @param[in] str pointer to the string.
- * @param[in] length how many bytes to print to the serial port.
+ * @param[in] strptr pointer to the string.
  */
 void bp_message_write_buffer(unsigned long strptr);
 
@@ -48,8 +47,7 @@ void bp_message_write_buffer(unsigned long strptr);
  * Prints a given byte array range from the packed string buffer to the serial
  * port, appending a CRLF pair at the end.
  * 
- * @param[in] str pointer to the string.
- * @param[in] length how many bytes to print to the serial port.
+ * @param[in] strptr pointer to the string.
  */
 void bp_message_write_line(unsigned long strptr);
 

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -42,7 +42,7 @@ void print_help(void);
  * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_buffer(unsigned long strptr, size_t length);
+void bp_message_write_buffer(unsigned long strptr);
 
 /**
  * Prints a given byte array range from the packed string buffer to the serial
@@ -51,7 +51,7 @@ void bp_message_write_buffer(unsigned long strptr, size_t length);
  * @param[in] str pointer to the string.
  * @param[in] length how many bytes to print to the serial port.
  */
-void bp_message_write_line(unsigned long strptr, size_t length);
+void bp_message_write_line(unsigned long strptr);
 
 /**
  * Prompts the user to agree or not on a particular question.

--- a/Firmware/messages_v3.h
+++ b/Firmware/messages_v3.h
@@ -2,566 +2,566 @@
 #define BP_MESSAGES_V3_H
 
 void BPMSG1004_str(void);
-#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str), 41)
+#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str))
 void BPMSG1005_str(void);
-#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str), 14)
+#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str))
 void BPMSG1006_str(void);
-#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str), 13)
+#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str))
 void BPMSG1007_str(void);
-#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str), 23)
+#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str))
 void BPMSG1008_str(void);
-#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str), 6)
+#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str))
 void BPMSG1009_str(void);
-#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str), 211)
+#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str))
 void BPMSG1010_str(void);
-#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str), 19)
+#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str))
 void BPMSG1011_str(void);
-#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str), 13)
+#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str))
 void BPMSG1012_str(void);
-#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str), 43)
+#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str))
 void BPMSG1013_str(void);
-#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str), 17)
+#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str))
 void BPMSG1014_str(void);
-#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str), 16)
+#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str))
 void BPMSG1015_str(void);
-#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str), 15)
+#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str))
 void BPMSG1017_str(void);
-#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str), 10)
+#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str))
 void BPMSG1019_str(void);
-#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str), 9)
+#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str))
 void BPMSG1020_str(void);
-#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str), 21)
+#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str))
 void BPMSG1021_str(void);
-#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str), 20)
+#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str))
 void BPMSG1022_str(void);
-#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str), 27)
+#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str))
 void BPMSG1023_str(void);
-#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str), 26)
+#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str))
 void BPMSG1024_str(void);
-#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str), 21)
+#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str))
 void BPMSG1025_str(void);
-#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str), 24)
+#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str))
 void BPMSG1026_str(void);
-#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str), 16)
+#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str))
 void BPMSG1027_str(void);
-#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str), 14)
+#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str))
 void BPMSG1028_str(void);
-#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str), 12)
+#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str))
 void BPMSG1029_str(void);
-#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str), 17)
+#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str))
 void BPMSG1030_str(void);
-#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str), 17)
+#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str))
 void BPMSG1033_str(void);
-#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str), 16)
+#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str))
 void BPMSG1034_str(void);
-#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str), 10)
+#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str))
 void BPMSG1037_str(void);
-#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str), 31)
+#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str))
 void BPMSG1038_str(void);
-#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str), 15)
+#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str))
 void BPMSG1039_str(void);
-#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str), 14)
+#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str))
 void BPMSG1040_str(void);
-#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str), 8)
+#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str))
 void BPMSG1041_str(void);
-#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str), 7)
+#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str))
 void BPMSG1042_str(void);
-#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str), 14)
+#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str))
 void BPMSG1044_str(void);
-#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str), 15)
+#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str))
 void BPMSG1045_str(void);
-#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str), 1)
+#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str))
 void BPMSG1047_str(void);
-#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str), 6)
+#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str))
 void BPMSG1048_str(void);
-#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str), 8)
+#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str))
 void BPMSG1049_str(void);
-#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str), 11)
+#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str))
 void BPMSG1050_str(void);
-#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str), 7)
+#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str))
 void BPMSG1051_str(void);
-#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str), 9)
+#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str))
 void BPMSG1052_str(void);
-#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str), 12)
+#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str))
 void BPMSG1059_str(void);
-#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str), 33)
+#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str))
 void BPMSG1064_str(void);
-#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str), 37)
+#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str))
 void BPMSG1066_str(void);
-#define BPMSG1066 bp_message_write_buffer(__builtin_tbladdress(BPMSG1066_str), 53)
+#define BPMSG1066 bp_message_write_buffer(__builtin_tbladdress(BPMSG1066_str))
 void BPMSG1067_str(void);
-#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str), 44)
+#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str))
 void BPMSG1068_str(void);
-#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str), 16)
+#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str))
 void BPMSG1069_str(void);
-#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str), 53)
+#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str))
 void BPMSG1070_str(void);
-#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str), 46)
+#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str))
 void BPMSG1072_str(void);
-#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str), 34)
+#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str))
 void BPMSG1073_str(void);
-#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str), 6)
+#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str))
 void BPMSG1074_str(void);
-#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str), 14)
+#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str))
 void BPMSG1075_str(void);
-#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str), 3)
+#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str))
 void BPMSG1076_str(void);
-#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str), 3)
+#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str))
 void BPMSG1077_str(void);
-#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str), 7)
+#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str))
 void BPMSG1078_str(void);
-#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str), 12)
+#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str))
 void BPMSG1079_str(void);
-#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str), 13)
+#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str))
 void BPMSG1080_str(void);
-#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str), 8)
+#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str))
 void BPMSG1081_str(void);
-#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str), 7)
+#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str))
 void BPMSG1082_str(void);
-#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str), 21)
+#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str))
 void BPMSG1083_str(void);
-#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str), 32)
+#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str))
 void BPMSG1084_str(void);
-#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str), 7)
+#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str))
 void BPMSG1085_str(void);
-#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str), 5)
+#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str))
 void BPMSG1086_str(void);
-#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str), 22)
+#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str))
 void BPMSG1087_str(void);
-#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str), 21)
+#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str))
 void BPMSG1088_str(void);
-#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str), 29)
+#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str))
 void BPMSG1089_str(void);
-#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str), 21)
+#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str))
 void BPMSG1091_str(void);
-#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str), 20)
+#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str))
 void BPMSG1092_str(void);
-#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str), 26)
+#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str))
 void BPMSG1093_str(void);
-#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str), 5)
+#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str))
 void BPMSG1094_str(void);
-#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str), 10)
+#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str))
 void BPMSG1095_str(void);
-#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str), 22)
+#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str))
 void BPMSG1096_str(void);
-#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str), 17)
+#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str))
 void BPMSG1097_str(void);
-#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str), 18)
+#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str))
 void BPMSG1098_str(void);
-#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str), 12)
+#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str))
 void BPMSG1099_str(void);
-#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str), 6)
+#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str))
 void BPMSG1100_str(void);
-#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str), 2)
+#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str))
 void BPMSG1101_str(void);
-#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str), 7)
+#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str))
 void BPMSG1102_str(void);
-#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str), 6)
+#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str))
 void BPMSG1103_str(void);
-#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str), 8)
+#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str))
 void BPMSG1104_str(void);
-#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str), 8)
+#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str))
 void BPMSG1105_str(void);
-#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str), 14)
+#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str))
 void BPMSG1106_str(void);
-#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str), 14)
+#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str))
 void BPMSG1107_str(void);
-#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str), 16)
+#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str))
 void BPMSG1108_str(void);
-#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str), 13)
+#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str))
 void BPMSG1109_str(void);
-#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str), 10)
+#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str))
 void BPMSG1110_str(void);
-#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str), 21)
+#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str))
 void BPMSG1111_str(void);
-#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str), 23)
+#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str))
 void BPMSG1112_str(void);
-#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str), 14)
+#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str))
 void BPMSG1114_str(void);
-#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str), 21)
+#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str))
 void BPMSG1115_str(void);
-#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str), 7)
+#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str))
 void BPMSG1117_str(void);
-#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str), 6)
+#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str))
 void BPMSG1118_str(void);
-#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str), 30)
+#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str))
 void BPMSG1119_str(void);
-#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str), 12)
+#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str))
 void BPMSG1120_str(void);
-#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str), 34)
+#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str))
 void BPMSG1121_str(void);
-#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str), 30)
+#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str))
 void BPMSG1123_str(void);
-#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str), 27)
+#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str))
 void BPMSG1124_str(void);
-#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str), 28)
+#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str))
 void BPMSG1126_str(void);
-#define BPMSG1126 bp_message_write_buffer(__builtin_tbladdress(BPMSG1126_str), 13)
+#define BPMSG1126 bp_message_write_buffer(__builtin_tbladdress(BPMSG1126_str))
 void BPMSG1127_str(void);
-#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str), 34)
+#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str))
 void BPMSG1128_str(void);
-#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str), 18)
+#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str))
 void BPMSG1133_str(void);
-#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str), 141)
+#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str))
 void BPMSG1134_str(void);
-#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str), 20)
+#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str))
 void BPMSG1135_str(void);
-#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str), 14)
+#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str))
 void BPMSG1136_str(void);
-#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str), 5)
+#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str))
 void BPMSG1137_str(void);
-#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str), 6)
+#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str))
 void BPMSG1163_str(void);
-#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str), 63)
+#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str))
 void BPMSG1164_str(void);
-#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str), 4)
+#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str))
 void BPMSG1165_str(void);
-#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str), 3)
+#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str))
 void BPMSG1166_str(void);
-#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str), 8)
+#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str))
 void BPMSG1167_str(void);
-#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str), 8)
+#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str))
 void BPMSG1168_str(void);
-#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str), 8)
+#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str))
 void BPMSG1169_str(void);
-#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str), 4)
+#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str))
 void BPMSG1170_str(void);
-#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str), 14)
+#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str))
 void BPMSG1171_str(void);
-#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str), 2)
+#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str))
 void BPMSG1172_str(void);
-#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str), 3)
+#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str))
 void BPMSG1173_str(void);
-#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str), 4)
+#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str))
 void BPMSG1174_str(void);
-#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str), 3)
+#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str))
 void BPMSG1175_str(void);
-#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str), 8)
+#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str))
 void BPMSG1176_str(void);
-#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str), 10)
+#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str))
 void BPMSG1177_str(void);
-#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str), 10)
+#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str))
 void BPMSG1178_str(void);
-#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str), 32)
+#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str))
 void BPMSG1179_str(void);
-#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str), 6)
+#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str))
 void BPMSG1180_str(void);
-#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str), 8)
+#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str))
 void BPMSG1181_str(void);
-#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str), 4)
+#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str))
 void BPMSG1182_str(void);
-#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str), 3)
+#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str))
 void BPMSG1183_str(void);
-#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str), 4)
+#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str))
 void BPMSG1184_str(void);
-#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str), 2)
+#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str))
 void BPMSG1185_str(void);
-#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str), 3)
+#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str))
 void BPMSG1186_str(void);
-#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str), 5)
+#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str))
 void BPMSG1194_str(void);
-#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str), 3)
+#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str))
 void BPMSG1195_str(void);
-#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str), 3)
+#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str))
 void BPMSG1196_str(void);
-#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str), 15)
+#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str))
 void BPMSG1197_str(void);
-#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str), 15)
+#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str))
 void BPMSG1199_str(void);
-#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str), 84)
+#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str))
 void BPMSG1200_str(void);
-#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str), 33)
+#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str))
 void BPMSG1201_str(void);
-#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str), 50)
+#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str))
 void BPMSG1202_str(void);
-#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str), 32)
+#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str))
 void BPMSG1203_str(void);
-#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str), 106)
+#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str))
 void BPMSG1204_str(void);
-#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str), 11)
+#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str))
 void BPMSG1206_str(void);
-#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str), 14)
+#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str))
 void BPMSG1207_str(void);
-#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str), 28)
+#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str))
 void BPMSG1208_str(void);
-#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str), 20)
+#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str))
 void BPMSG1209_str(void);
-#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str), 34)
+#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str))
 void BPMSG1210_str(void);
-#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str), 7)
+#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str))
 void BPMSG1211_str(void);
-#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str), 27)
+#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str))
 void BPMSG1212_str(void);
-#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str), 2)
+#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str))
 void BPMSG1213_str(void);
-#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str), 20)
+#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str))
 void BPMSG1214_str(void);
-#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str), 18)
+#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str))
 void BPMSG1216_str(void);
-#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str), 29)
+#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str))
 void BPMSG1219_str(void);
-#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str), 152)
+#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str))
 void BPMSG1220_str(void);
-#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str), 36)
+#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str))
 void BPMSG1221_str(void);
-#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str), 4)
+#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str))
 void BPMSG1222_str(void);
-#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str), 5)
+#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str))
 void BPMSG1223_str(void);
-#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str), 10)
+#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str))
 void BPMSG1226_str(void);
-#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str), 10)
+#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str))
 void BPMSG1227_str(void);
-#define BPMSG1227 bp_message_write_buffer(__builtin_tbladdress(BPMSG1227_str), 26)
+#define BPMSG1227 bp_message_write_buffer(__builtin_tbladdress(BPMSG1227_str))
 void BPMSG1228_str(void);
-#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str), 10)
+#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str))
 void BPMSG1229_str(void);
-#define BPMSG1229 bp_message_write_line(__builtin_tbladdress(BPMSG1229_str), 9)
+#define BPMSG1229 bp_message_write_line(__builtin_tbladdress(BPMSG1229_str))
 void BPMSG1232_str(void);
-#define BPMSG1232 bp_message_write_line(__builtin_tbladdress(BPMSG1232_str), 11)
+#define BPMSG1232 bp_message_write_line(__builtin_tbladdress(BPMSG1232_str))
 void BPMSG1233_str(void);
-#define BPMSG1233 bp_message_write_line(__builtin_tbladdress(BPMSG1233_str), 70)
+#define BPMSG1233 bp_message_write_line(__builtin_tbladdress(BPMSG1233_str))
 void BPMSG1234_str(void);
-#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str), 4)
+#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str))
 void BPMSG1237_str(void);
-#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str), 8)
+#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str))
 void BPMSG1238_str(void);
-#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str), 38)
+#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str))
 void BPMSG1239_str(void);
-#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str), 28)
+#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str))
 void BPMSG1240_str(void);
-#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str), 16)
+#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str))
 void BPMSG1241_str(void);
-#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str), 14)
+#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str))
 void BPMSG1242_str(void);
-#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str), 15)
+#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str))
 void BPMSG1243_str(void);
-#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str), 5)
+#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str))
 void BPMSG1244_str(void);
-#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str), 14)
+#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str))
 void BPMSG1245_str(void);
-#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str), 11)
+#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str))
 void BPMSG1248_str(void);
-#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str), 28)
+#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str))
 void BPMSG1251_str(void);
-#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str), 17)
+#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str))
 void BPMSG1252_str(void);
-#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str), 27)
+#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str))
 void BPMSG1254_str(void);
-#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str), 19)
+#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str))
 void BPMSG1255_str(void);
-#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str), 12)
+#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str))
 void BPMSG1280_str(void);
-#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str), 19)
+#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str))
 void BPMSG1281_str(void);
-#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str), 14)
+#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str))
 void BPMSG1282_str(void);
-#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str), 47)
+#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str))
 void BPMSG1283_str(void);
-#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str), 15)
+#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str))
 void BPMSG1284_str(void);
-#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str), 15)
+#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str))
 void BPMSG1285_str(void);
-#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str), 4)
+#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str))
 void HLP1000_str(void);
-#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str), 33)
+#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str))
 void HLP1001_str(void);
-#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str), 76)
+#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str))
 void HLP1002_str(void);
-#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str), 38)
+#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str))
 void HLP1003_str(void);
-#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str), 40)
+#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str))
 void HLP1004_str(void);
-#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str), 21)
+#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str))
 void HLP1005_str(void);
-#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str), 27)
+#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str))
 void HLP1006_str(void);
-#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str), 40)
+#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str))
 void HLP1007_str(void);
-#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str), 27)
+#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str))
 void HLP1008_str(void);
-#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str), 46)
+#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str))
 void HLP1009_str(void);
-#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str), 21)
+#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str))
 void HLP1010_str(void);
-#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str), 35)
+#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str))
 void HLP1011_str(void);
-#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str), 46)
+#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str))
 void HLP1012_str(void);
-#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str), 28)
+#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str))
 void HLP1013_str(void);
-#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str), 33)
+#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str))
 void HLP1014_str(void);
-#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str), 28)
+#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str))
 void HLP1015_str(void);
-#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str), 37)
+#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str))
 void HLP1016_str(void);
-#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str), 33)
+#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str))
 void HLP1017_str(void);
-#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str), 25)
+#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str))
 void HLP1018_str(void);
-#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str), 31)
+#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str))
 void HLP1019_str(void);
-#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str), 41)
+#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str))
 void HLP1020_str(void);
-#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str), 37)
+#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str))
 void HLP1021_str(void);
-#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str), 54)
+#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str))
 void HLP1022_str(void);
-#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str), 62)
+#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str))
 void MSG_1WIRE_MODE_IDENTIFIER_str(void);
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str), 4)
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str))
 void MSG_1WIRE_NEXT_CLOCK_ALERT_str(void);
-#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str), 36)
+#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str))
 void MSG_1WIRE_SPEED_PROMPT_str(void);
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str), 62)
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str))
 void MSG_ACK_str(void);
-#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str), 3)
+#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str))
 void MSG_ANY_KEY_TO_EXIT_PROMPT_str(void);
-#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str), 15)
+#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str))
 void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str), 3)
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str))
 void MSG_BBIO_MODE_IDENTIFIER_str(void);
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str), 5)
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str))
 void MSG_BINARY_NUMBER_PREFIX_str(void);
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str), 2)
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str))
 void MSG_CHIP_IDENTIFIER_CLONE_str(void);
-#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_IDENTIFIER_CLONE_str), 22)
+#define MSG_CHIP_IDENTIFIER_CLONE bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_IDENTIFIER_CLONE_str))
 void MSG_CHIP_REVISION_A3_str(void);
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str), 2)
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str))
 void MSG_CHIP_REVISION_B4_str(void);
-#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B4_str), 2)
+#define MSG_CHIP_REVISION_B4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B4_str))
 void MSG_CHIP_REVISION_B5_str(void);
-#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B5_str), 2)
+#define MSG_CHIP_REVISION_B5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B5_str))
 void MSG_CHIP_REVISION_B8_str(void);
-#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B8_str), 2)
+#define MSG_CHIP_REVISION_B8 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_B8_str))
 void MSG_CHIP_REVISION_ID_BEGIN_str(void);
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str), 13)
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str))
 void MSG_CHIP_REVISION_ID_END_2_str(void);
-#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_2_str), 2)
+#define MSG_CHIP_REVISION_ID_END_2 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_2_str))
 void MSG_CHIP_REVISION_ID_END_4_str(void);
-#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_4_str), 2)
+#define MSG_CHIP_REVISION_ID_END_4 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_END_4_str))
 void MSG_CHIP_REVISION_UNKNOWN_str(void);
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str), 3)
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str))
 void MSG_CLUTCH_DISENGAGED_str(void);
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str), 20)
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str))
 void MSG_CLUTCH_ENGAGED_str(void);
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str), 17)
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str))
 void MSG_FINISH_SETUP_PROMPT_str(void);
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str), 61)
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str))
 void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str), 2)
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str))
 void MSG_I2C_MODE_IDENTIFIER_str(void);
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str), 4)
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str))
 void MSG_I2C_PINS_STATE_str(void);
-#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str), 11)
+#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str))
 void MSG_I2C_READ_ADDRESS_END_str(void);
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str), 4)
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str))
 void MSG_I2C_START_BIT_str(void);
-#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str), 13)
+#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str))
 void MSG_I2C_STOP_BIT_str(void);
-#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str), 12)
+#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str))
 void MSG_I2C_WRITE_ADDRESS_END_str(void);
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str), 4)
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str))
 void MSG_MODE_HEADER_END_str(void);
-#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str), 2)
+#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str))
 void MSG_NACK_str(void);
-#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str), 4)
+#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str))
 void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str), 34)
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str))
 void MSG_OPENOCD_MODE_IDENTIFIER_str(void);
-#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_OPENOCD_MODE_IDENTIFIER_str), 4)
+#define MSG_OPENOCD_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_OPENOCD_MODE_IDENTIFIER_str))
 void MSG_PIC_MODE_IDENTIFIER_str(void);
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str), 4)
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str))
 void MSG_PIC_UNKNOWN_MODE_str(void);
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str), 12)
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str))
 void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str), 79)
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str))
 void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str), 36)
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str))
 void MSG_PWM_HZ_MARKER_str(void);
-#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str), 3)
+#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str))
 void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str), 12)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str))
 void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str), 13)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str))
 void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str), 25)
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str), 10)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str), 7)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str), 11)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str), 6)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str), 15)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str))
 void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str), 45)
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str))
 void MSG_RAW2WIRE_ATR_RFU_str(void);
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str), 3)
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str))
 void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str), 63)
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str))
 void MSG_RAW2WIRE_I2C_START_str(void);
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str), 8)
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str))
 void MSG_RAW2WIRE_I2C_STOP_str(void);
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str), 6)
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str))
 void MSG_RAW2WIRE_MACRO_MENU_str(void);
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str), 56)
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str))
 void MSG_RAW2WIRE_MODE_HEADER_str(void);
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str), 16)
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str))
 void MSG_RAW3WIRE_MODE_HEADER_str(void);
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str), 20)
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str))
 void MSG_RAW_BRG_VALUE_INPUT_str(void);
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str), 23)
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str))
 void MSG_RAW_MODE_IDENTIFIER_str(void);
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str), 4)
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str))
 void MSG_SNIFFER_MESSAGE_str(void);
-#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str), 7)
+#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str))
 void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str), 59)
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str))
 void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str), 16)
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str))
 void MSG_SPI_CS_DISABLED_str(void);
-#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str), 11)
+#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str))
 void MSG_SPI_CS_ENABLED_str(void);
-#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str), 10)
+#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str))
 void MSG_SPI_CS_MODE_PROMPT_str(void);
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str), 29)
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str))
 void MSG_SPI_EDGE_PROMPT_str(void);
-#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str), 67)
+#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str))
 void MSG_SPI_MACRO_MENU_str(void);
-#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str), 206)
+#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str))
 void MSG_SPI_MODE_HEADER_START_str(void);
-#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str), 32)
+#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str))
 void MSG_SPI_MODE_IDENTIFIER_str(void);
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str), 4)
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str))
 void MSG_SPI_PINS_STATE_str(void);
-#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str), 16)
+#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str))
 void MSG_SPI_POLARITY_PROMPT_str(void);
-#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str), 53)
+#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str))
 void MSG_SPI_SAMPLE_PROMPT_str(void);
-#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str), 49)
+#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str))
 void MSG_SPI_SPEED_PROMPT_str(void);
-#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str), 154)
+#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str))
 void MSG_UART_MODE_IDENTIFIER_str(void);
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str), 4)
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str))
 void MSG_UART_PINS_STATE_str(void);
-#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str), 11)
+#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str))
 void MSG_UART_POSSIBLE_OVERFLOW_str(void);
-#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(__builtin_tbladdress(MSG_UART_POSSIBLE_OVERFLOW_str), 33)
+#define MSG_UART_POSSIBLE_OVERFLOW bp_message_write_line(__builtin_tbladdress(MSG_UART_POSSIBLE_OVERFLOW_str))
 void MSG_UART_RESET_TO_EXIT_str(void);
-#define MSG_UART_RESET_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_RESET_TO_EXIT_str), 13)
+#define MSG_UART_RESET_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_RESET_TO_EXIT_str))
 void MSG_UNKNOWN_MACRO_ERROR_str(void);
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str), 36)
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str))
 void MSG_VREG_TOO_LOW_str(void);
-#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str), 31)
+#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str))
 
 #endif /* BP_MESSAGES_V3_H */

--- a/Firmware/messages_v3.s
+++ b/Firmware/messages_v3.s
@@ -2,1685 +2,1685 @@
 	.section .text.BPMSG1004, code
 	.global _BPMSG1004_str
 _BPMSG1004_str:
-	.pascii "No device, try (ALARM) SEARCH macro first"
+	.pasciz "No device, try (ALARM) SEARCH macro first"
 
 	; BPMSG1005
 	.section .text.BPMSG1005, code
 	.global _BPMSG1005_str
 _BPMSG1005_str:
-	.pascii "ADDRESS MACRO "
+	.pasciz "ADDRESS MACRO "
 
 	; BPMSG1006
 	.section .text.BPMSG1006, code
 	.global _BPMSG1006_str
 _BPMSG1006_str:
-	.pascii " 0.Macro menu"
+	.pasciz " 0.Macro menu"
 
 	; BPMSG1007
 	.section .text.BPMSG1007, code
 	.global _BPMSG1007_str
 _BPMSG1007_str:
-	.pascii "Macro     1WIRE address"
+	.pasciz "Macro     1WIRE address"
 
 	; BPMSG1008
 	.section .text.BPMSG1008, code
 	.global _BPMSG1008_str
 _BPMSG1008_str:
-	.pascii "\r\n   *"
+	.pasciz "\r\n   *"
 
 	; BPMSG1009
 	.section .text.BPMSG1009, code
 	.global _BPMSG1009_str
 _BPMSG1009_str:
-	.pascii "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
+	.pasciz "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
 
 	; BPMSG1010
 	.section .text.BPMSG1010, code
 	.global _BPMSG1010_str
 _BPMSG1010_str:
-	.pascii "ALARM SEARCH (0xEC)"
+	.pasciz "ALARM SEARCH (0xEC)"
 
 	; BPMSG1011
 	.section .text.BPMSG1011, code
 	.global _BPMSG1011_str
 _BPMSG1011_str:
-	.pascii "SEARCH (0xF0)"
+	.pasciz "SEARCH (0xF0)"
 
 	; BPMSG1012
 	.section .text.BPMSG1012, code
 	.global _BPMSG1012_str
 _BPMSG1012_str:
-	.pascii "Device IDs are available by MACRO, see (0)."
+	.pasciz "Device IDs are available by MACRO, see (0)."
 
 	; BPMSG1013
 	.section .text.BPMSG1013, code
 	.global _BPMSG1013_str
 _BPMSG1013_str:
-	.pascii "READ ROM (0x33): "
+	.pasciz "READ ROM (0x33): "
 
 	; BPMSG1014
 	.section .text.BPMSG1014, code
 	.global _BPMSG1014_str
 _BPMSG1014_str:
-	.pascii "MATCH ROM (0x55)"
+	.pasciz "MATCH ROM (0x55)"
 
 	; BPMSG1015
 	.section .text.BPMSG1015, code
 	.global _BPMSG1015_str
 _BPMSG1015_str:
-	.pascii "SKIP ROM (0xCC)"
+	.pasciz "SKIP ROM (0xCC)"
 
 	; BPMSG1017
 	.section .text.BPMSG1017, code
 	.global _BPMSG1017_str
 _BPMSG1017_str:
-	.pascii "BUS RESET "
+	.pasciz "BUS RESET "
 
 	; BPMSG1019
 	.section .text.BPMSG1019, code
 	.global _BPMSG1019_str
 _BPMSG1019_str:
-	.pascii "Warning: "
+	.pasciz "Warning: "
 
 	; BPMSG1020
 	.section .text.BPMSG1020, code
 	.global _BPMSG1020_str
 _BPMSG1020_str:
-	.pascii "*Short or no pull-up "
+	.pasciz "*Short or no pull-up "
 
 	; BPMSG1021
 	.section .text.BPMSG1021, code
 	.global _BPMSG1021_str
 _BPMSG1021_str:
-	.pascii "*No device detected "
+	.pasciz "*No device detected "
 
 	; BPMSG1022
 	.section .text.BPMSG1022, code
 	.global _BPMSG1022_str
 _BPMSG1022_str:
-	.pascii "DS18S20 High Pres Dig Therm"
+	.pasciz "DS18S20 High Pres Dig Therm"
 
 	; BPMSG1023
 	.section .text.BPMSG1023, code
 	.global _BPMSG1023_str
 _BPMSG1023_str:
-	.pascii "DS18B20 Prog Res Dig Therm"
+	.pasciz "DS18B20 Prog Res Dig Therm"
 
 	; BPMSG1024
 	.section .text.BPMSG1024, code
 	.global _BPMSG1024_str
 _BPMSG1024_str:
-	.pascii "DS1822 Econ Dig Therm"
+	.pasciz "DS1822 Econ Dig Therm"
 
 	; BPMSG1025
 	.section .text.BPMSG1025, code
 	.global _BPMSG1025_str
 _BPMSG1025_str:
-	.pascii "DS2404 Econram time Chip"
+	.pasciz "DS2404 Econram time Chip"
 
 	; BPMSG1026
 	.section .text.BPMSG1026, code
 	.global _BPMSG1026_str
 _BPMSG1026_str:
-	.pascii "DS2431 1K EEPROM"
+	.pasciz "DS2431 1K EEPROM"
 
 	; BPMSG1027
 	.section .text.BPMSG1027, code
 	.global _BPMSG1027_str
 _BPMSG1027_str:
-	.pascii "Unknown device"
+	.pasciz "Unknown device"
 
 	; BPMSG1028
 	.section .text.BPMSG1028, code
 	.global _BPMSG1028_str
 _BPMSG1028_str:
-	.pascii "PWM disabled"
+	.pasciz "PWM disabled"
 
 	; BPMSG1029
 	.section .text.BPMSG1029, code
 	.global _BPMSG1029_str
 _BPMSG1029_str:
-	.pascii "1KHz-4,000KHz PWM"
+	.pasciz "1KHz-4,000KHz PWM"
 
 	; BPMSG1030
 	.section .text.BPMSG1030, code
 	.global _BPMSG1030_str
 _BPMSG1030_str:
-	.pascii "Frequency in KHz "
+	.pasciz "Frequency in KHz "
 
 	; BPMSG1033
 	.section .text.BPMSG1033, code
 	.global _BPMSG1033_str
 _BPMSG1033_str:
-	.pascii "Duty cycle in % "
+	.pasciz "Duty cycle in % "
 
 	; BPMSG1034
 	.section .text.BPMSG1034, code
 	.global _BPMSG1034_str
 _BPMSG1034_str:
-	.pascii "PWM active"
+	.pasciz "PWM active"
 
 	; BPMSG1037
 	.section .text.BPMSG1037, code
 	.global _BPMSG1037_str
 _BPMSG1037_str:
-	.pascii "ERROR: PWM active, g to disable"
+	.pasciz "ERROR: PWM active, g to disable"
 
 	; BPMSG1038
 	.section .text.BPMSG1038, code
 	.global _BPMSG1038_str
 _BPMSG1038_str:
-	.pascii "AUX Frequency: "
+	.pasciz "AUX Frequency: "
 
 	; BPMSG1039
 	.section .text.BPMSG1039, code
 	.global _BPMSG1039_str
 _BPMSG1039_str:
-	.pascii "AUX INPUT/HI-Z"
+	.pasciz "AUX INPUT/HI-Z"
 
 	; BPMSG1040
 	.section .text.BPMSG1040, code
 	.global _BPMSG1040_str
 _BPMSG1040_str:
-	.pascii "AUX HIGH"
+	.pasciz "AUX HIGH"
 
 	; BPMSG1041
 	.section .text.BPMSG1041, code
 	.global _BPMSG1041_str
 _BPMSG1041_str:
-	.pascii "AUX LOW"
+	.pasciz "AUX LOW"
 
 	; BPMSG1042
 	.section .text.BPMSG1042, code
 	.global _BPMSG1042_str
 _BPMSG1042_str:
-	.pascii "VOLTMETER MODE"
+	.pasciz "VOLTMETER MODE"
 
 	; BPMSG1044
 	.section .text.BPMSG1044, code
 	.global _BPMSG1044_str
 _BPMSG1044_str:
-	.pascii "VOLTAGE PROBE: "
+	.pasciz "VOLTAGE PROBE: "
 
 	; BPMSG1045
 	.section .text.BPMSG1045, code
 	.global _BPMSG1045_str
 _BPMSG1045_str:
-	.pascii "V"
+	.pasciz "V"
 
 	; BPMSG1047
 	.section .text.BPMSG1047, code
 	.global _BPMSG1047_str
 _BPMSG1047_str:
-	.pascii "Error("
+	.pasciz "Error("
 
 	; BPMSG1048
 	.section .text.BPMSG1048, code
 	.global _BPMSG1048_str
 _BPMSG1048_str:
-	.pascii ") @line:"
+	.pasciz ") @line:"
 
 	; BPMSG1049
 	.section .text.BPMSG1049, code
 	.global _BPMSG1049_str
 _BPMSG1049_str:
-	.pascii " @pgmspace:"
+	.pasciz " @pgmspace:"
 
 	; BPMSG1050
 	.section .text.BPMSG1050, code
 	.global _BPMSG1050_str
 _BPMSG1050_str:
-	.pascii " bytes."
+	.pasciz " bytes."
 
 	; BPMSG1051
 	.section .text.BPMSG1051, code
 	.global _BPMSG1051_str
 _BPMSG1051_str:
-	.pascii "Too long!"
+	.pasciz "Too long!"
 
 	; BPMSG1052
 	.section .text.BPMSG1052, code
 	.global _BPMSG1052_str
 _BPMSG1052_str:
-	.pascii "Syntax error"
+	.pasciz "Syntax error"
 
 	; BPMSG1059
 	.section .text.BPMSG1059, code
 	.global _BPMSG1059_str
 _BPMSG1059_str:
-	.pascii "ERROR: command has no effect here"
+	.pasciz "ERROR: command has no effect here"
 
 	; BPMSG1064
 	.section .text.BPMSG1064, code
 	.global _BPMSG1064_str
 _BPMSG1064_str:
-	.pascii "I2C mode:\r\n 1. Software\r\n 2. Hardware"
+	.pasciz "I2C mode:\r\n 1. Software\r\n 2. Hardware"
 
 	; BPMSG1066
 	.section .text.BPMSG1066, code
 	.global _BPMSG1066_str
 _BPMSG1066_str:
-	.pascii "WARNING: HARDWARE I2C is broken on this PIC! (REV A3)"
+	.pasciz "WARNING: HARDWARE I2C is broken on this PIC! (REV A3)"
 
 	; BPMSG1067
 	.section .text.BPMSG1067, code
 	.global _BPMSG1067_str
 _BPMSG1067_str:
-	.pascii "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
+	.pasciz "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
 
 	; BPMSG1068
 	.section .text.BPMSG1068, code
 	.global _BPMSG1068_str
 _BPMSG1068_str:
-	.pascii "I2C (mod spd)=( "
+	.pasciz "I2C (mod spd)=( "
 
 	; BPMSG1069
 	.section .text.BPMSG1069, code
 	.global _BPMSG1069_str
 _BPMSG1069_str:
-	.pascii " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer"
+	.pasciz " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer"
 
 	; BPMSG1070
 	.section .text.BPMSG1070, code
 	.global _BPMSG1070_str
 _BPMSG1070_str:
-	.pascii "Searching I2C address space. Found devices at:"
+	.pasciz "Searching I2C address space. Found devices at:"
 
 	; BPMSG1072
 	.section .text.BPMSG1072, code
 	.global _BPMSG1072_str
 _BPMSG1072_str:
-	.pascii "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
+	.pasciz "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
 
 	; BPMSG1073
 	.section .text.BPMSG1073, code
 	.global _BPMSG1073_str
 _BPMSG1073_str:
-	.pascii "Delay?"
+	.pasciz "Delay?"
 
 	; BPMSG1074
 	.section .text.BPMSG1074, code
 	.global _BPMSG1074_str
 _BPMSG1074_str:
-	.pascii "PIC(mod dly)=("
+	.pasciz "PIC(mod dly)=("
 
 	; BPMSG1075
 	.section .text.BPMSG1075, code
 	.global _BPMSG1075_str
 _BPMSG1075_str:
-	.pascii "CMD"
+	.pasciz "CMD"
 
 	; BPMSG1076
 	.section .text.BPMSG1076, code
 	.global _BPMSG1076_str
 _BPMSG1076_str:
-	.pascii "DTA"
+	.pasciz "DTA"
 
 	; BPMSG1077
 	.section .text.BPMSG1077, code
 	.global _BPMSG1077_str
 _BPMSG1077_str:
-	.pascii "no read"
+	.pasciz "no read"
 
 	; BPMSG1078
 	.section .text.BPMSG1078, code
 	.global _BPMSG1078_str
 _BPMSG1078_str:
-	.pascii "unknown mode"
+	.pasciz "unknown mode"
 
 	; BPMSG1079
 	.section .text.BPMSG1079, code
 	.global _BPMSG1079_str
 _BPMSG1079_str:
-	.pascii "(1) get devID"
+	.pasciz "(1) get devID"
 
 	; BPMSG1080
 	.section .text.BPMSG1080, code
 	.global _BPMSG1080_str
 _BPMSG1080_str:
-	.pascii "DevID = "
+	.pasciz "DevID = "
 
 	; BPMSG1081
 	.section .text.BPMSG1081, code
 	.global _BPMSG1081_str
 _BPMSG1081_str:
-	.pascii " Rev = "
+	.pasciz " Rev = "
 
 	; BPMSG1082
 	.section .text.BPMSG1082, code
 	.global _BPMSG1082_str
 _BPMSG1082_str:
-	.pascii "Not implemented (yet)"
+	.pasciz "Not implemented (yet)"
 
 	; BPMSG1083
 	.section .text.BPMSG1083, code
 	.global _BPMSG1083_str
 _BPMSG1083_str:
-	.pascii "Please exit PIC programming mode"
+	.pasciz "Please exit PIC programming mode"
 
 	; BPMSG1084
 	.section .text.BPMSG1084, code
 	.global _BPMSG1084_str
 _BPMSG1084_str:
-	.pascii "(BASIC)"
+	.pasciz "(BASIC)"
 
 	; BPMSG1085
 	.section .text.BPMSG1085, code
 	.global _BPMSG1085_str
 _BPMSG1085_str:
-	.pascii "Ready"
+	.pasciz "Ready"
 
 	; BPMSG1086
 	.section .text.BPMSG1086, code
 	.global _BPMSG1086_str
 _BPMSG1086_str:
-	.pascii "a/A/@ controls AUX pin"
+	.pasciz "a/A/@ controls AUX pin"
 
 	; BPMSG1087
 	.section .text.BPMSG1087, code
 	.global _BPMSG1087_str
 _BPMSG1087_str:
-	.pascii "a/A/@ controls CS pin"
+	.pasciz "a/A/@ controls CS pin"
 
 	; BPMSG1088
 	.section .text.BPMSG1088, code
 	.global _BPMSG1088_str
 _BPMSG1088_str:
-	.pascii "Command not used in this mode"
+	.pasciz "Command not used in this mode"
 
 	; BPMSG1089
 	.section .text.BPMSG1089, code
 	.global _BPMSG1089_str
 _BPMSG1089_str:
-	.pascii "Pull-up resistors OFF"
+	.pasciz "Pull-up resistors OFF"
 
 	; BPMSG1091
 	.section .text.BPMSG1091, code
 	.global _BPMSG1091_str
 _BPMSG1091_str:
-	.pascii "Pull-up resistors ON"
+	.pasciz "Pull-up resistors ON"
 
 	; BPMSG1092
 	.section .text.BPMSG1092, code
 	.global _BPMSG1092_str
 _BPMSG1092_str:
-	.pascii "Self-test in HiZ mode only"
+	.pasciz "Self-test in HiZ mode only"
 
 	; BPMSG1093
 	.section .text.BPMSG1093, code
 	.global _BPMSG1093_str
 _BPMSG1093_str:
-	.pascii "RESET"
+	.pasciz "RESET"
 
 	; BPMSG1094
 	.section .text.BPMSG1094, code
 	.global _BPMSG1094_str
 _BPMSG1094_str:
-	.pascii "BOOTLOADER"
+	.pasciz "BOOTLOADER"
 
 	; BPMSG1095
 	.section .text.BPMSG1095, code
 	.global _BPMSG1095_str
 _BPMSG1095_str:
-	.pascii "AUX INPUT/HI-Z, READ: "
+	.pasciz "AUX INPUT/HI-Z, READ: "
 
 	; BPMSG1096
 	.section .text.BPMSG1096, code
 	.global _BPMSG1096_str
 _BPMSG1096_str:
-	.pascii "POWER SUPPLIES ON"
+	.pasciz "POWER SUPPLIES ON"
 
 	; BPMSG1097
 	.section .text.BPMSG1097, code
 	.global _BPMSG1097_str
 _BPMSG1097_str:
-	.pascii "POWER SUPPLIES OFF"
+	.pasciz "POWER SUPPLIES OFF"
 
 	; BPMSG1098
 	.section .text.BPMSG1098, code
 	.global _BPMSG1098_str
 _BPMSG1098_str:
-	.pascii "DATA STATE: "
+	.pasciz "DATA STATE: "
 
 	; BPMSG1099
 	.section .text.BPMSG1099, code
 	.global _BPMSG1099_str
 _BPMSG1099_str:
-	.pascii "DELAY "
+	.pasciz "DELAY "
 
 	; BPMSG1100
 	.section .text.BPMSG1100, code
 	.global _BPMSG1100_str
 _BPMSG1100_str:
-	.pascii "us"
+	.pasciz "us"
 
 	; BPMSG1101
 	.section .text.BPMSG1101, code
 	.global _BPMSG1101_str
 _BPMSG1101_str:
-	.pascii "WRITE: "
+	.pasciz "WRITE: "
 
 	; BPMSG1102
 	.section .text.BPMSG1102, code
 	.global _BPMSG1102_str
 _BPMSG1102_str:
-	.pascii "READ: "
+	.pasciz "READ: "
 
 	; BPMSG1103
 	.section .text.BPMSG1103, code
 	.global _BPMSG1103_str
 _BPMSG1103_str:
-	.pascii "CLOCK, 1"
+	.pasciz "CLOCK, 1"
 
 	; BPMSG1104
 	.section .text.BPMSG1104, code
 	.global _BPMSG1104_str
 _BPMSG1104_str:
-	.pascii "CLOCK, 0"
+	.pasciz "CLOCK, 0"
 
 	; BPMSG1105
 	.section .text.BPMSG1105, code
 	.global _BPMSG1105_str
 _BPMSG1105_str:
-	.pascii "DATA OUTPUT, 1"
+	.pasciz "DATA OUTPUT, 1"
 
 	; BPMSG1106
 	.section .text.BPMSG1106, code
 	.global _BPMSG1106_str
 _BPMSG1106_str:
-	.pascii "DATA OUTPUT, 0"
+	.pasciz "DATA OUTPUT, 0"
 
 	; BPMSG1107
 	.section .text.BPMSG1107, code
 	.global _BPMSG1107_str
 _BPMSG1107_str:
-	.pascii " *pin is now HiZ"
+	.pasciz " *pin is now HiZ"
 
 	; BPMSG1108
 	.section .text.BPMSG1108, code
 	.global _BPMSG1108_str
 _BPMSG1108_str:
-	.pascii "CLOCK TICKS: "
+	.pasciz "CLOCK TICKS: "
 
 	; BPMSG1109
 	.section .text.BPMSG1109, code
 	.global _BPMSG1109_str
 _BPMSG1109_str:
-	.pascii "READ BIT: "
+	.pasciz "READ BIT: "
 
 	; BPMSG1110
 	.section .text.BPMSG1110, code
 	.global _BPMSG1110_str
 _BPMSG1110_str:
-	.pascii "Syntax error at char "
+	.pasciz "Syntax error at char "
 
 	; BPMSG1111
 	.section .text.BPMSG1111, code
 	.global _BPMSG1111_str
 _BPMSG1111_str:
-	.pascii "x. exit(without change)"
+	.pasciz "x. exit(without change)"
 
 	; BPMSG1112
 	.section .text.BPMSG1112, code
 	.global _BPMSG1112_str
 _BPMSG1112_str:
-	.pascii "no mode change"
+	.pasciz "no mode change"
 
 	; BPMSG1114
 	.section .text.BPMSG1114, code
 	.global _BPMSG1114_str
 _BPMSG1114_str:
-	.pascii "Nonexistent protocol!"
+	.pasciz "Nonexistent protocol!"
 
 	; BPMSG1115
 	.section .text.BPMSG1115, code
 	.global _BPMSG1115_str
 _BPMSG1115_str:
-	.pascii "x. exit"
+	.pasciz "x. exit"
 
 	; BPMSG1117
 	.section .text.BPMSG1117, code
 	.global _BPMSG1117_str
 _BPMSG1117_str:
-	.pascii "DEVID:"
+	.pasciz "DEVID:"
 
 	; BPMSG1118
 	.section .text.BPMSG1118, code
 	.global _BPMSG1118_str
 _BPMSG1118_str:
-	.pascii "http://dangerousprototypes.com"
+	.pasciz "http://dangerousprototypes.com"
 
 	; BPMSG1119
 	.section .text.BPMSG1119, code
 	.global _BPMSG1119_str
 _BPMSG1119_str:
-	.pascii "*----------*"
+	.pasciz "*----------*"
 
 	; BPMSG1120
 	.section .text.BPMSG1120, code
 	.global _BPMSG1120_str
 _BPMSG1120_str:
-	.pascii "Open drain outputs (H=Hi-Z, L=GND)"
+	.pasciz "Open drain outputs (H=Hi-Z, L=GND)"
 
 	; BPMSG1121
 	.section .text.BPMSG1121, code
 	.global _BPMSG1121_str
 _BPMSG1121_str:
-	.pascii "Normal outputs (H=3.3v, L=GND)"
+	.pasciz "Normal outputs (H=3.3v, L=GND)"
 
 	; BPMSG1123
 	.section .text.BPMSG1123, code
 	.global _BPMSG1123_str
 _BPMSG1123_str:
-	.pascii "MSB set: MOST sig bit first"
+	.pasciz "MSB set: MOST sig bit first"
 
 	; BPMSG1124
 	.section .text.BPMSG1124, code
 	.global _BPMSG1124_str
 _BPMSG1124_str:
-	.pascii "LSB set: LEAST sig bit first"
+	.pasciz "LSB set: LEAST sig bit first"
 
 	; BPMSG1126
 	.section .text.BPMSG1126, code
 	.global _BPMSG1126_str
 _BPMSG1126_str:
-	.pascii " Bootloader v"
+	.pasciz " Bootloader v"
 
 	; BPMSG1127
 	.section .text.BPMSG1127, code
 	.global _BPMSG1127_str
 _BPMSG1127_str:
-	.pascii " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
+	.pasciz " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
 
 	; BPMSG1128
 	.section .text.BPMSG1128, code
 	.global _BPMSG1128_str
 _BPMSG1128_str:
-	.pascii "Display format set"
+	.pasciz "Display format set"
 
 	; BPMSG1133
 	.section .text.BPMSG1133, code
 	.global _BPMSG1133_str
 _BPMSG1133_str:
-	.pascii "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. BRG raw value"
+	.pasciz "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. BRG raw value"
 
 	; BPMSG1134
 	.section .text.BPMSG1134, code
 	.global _BPMSG1134_str
 _BPMSG1134_str:
-	.pascii "Adjust your terminal"
+	.pasciz "Adjust your terminal"
 
 	; BPMSG1135
 	.section .text.BPMSG1135, code
 	.global _BPMSG1135_str
 _BPMSG1135_str:
-	.pascii "Are you sure? "
+	.pasciz "Are you sure? "
 
 	; BPMSG1136
 	.section .text.BPMSG1136, code
 	.global _BPMSG1136_str
 _BPMSG1136_str:
-	.pascii "CFG1:"
+	.pasciz "CFG1:"
 
 	; BPMSG1137
 	.section .text.BPMSG1137, code
 	.global _BPMSG1137_str
 _BPMSG1137_str:
-	.pascii " CFG2:"
+	.pasciz " CFG2:"
 
 	; BPMSG1163
 	.section .text.BPMSG1163, code
 	.global _BPMSG1163_str
 _BPMSG1163_str:
-	.pascii "Disconnect any devices\r\nConnect (Vpu to +5V) and (ADC to +3.3V)"
+	.pasciz "Disconnect any devices\r\nConnect (Vpu to +5V) and (ADC to +3.3V)"
 
 	; BPMSG1164
 	.section .text.BPMSG1164, code
 	.global _BPMSG1164_str
 _BPMSG1164_str:
-	.pascii "Ctrl"
+	.pasciz "Ctrl"
 
 	; BPMSG1165
 	.section .text.BPMSG1165, code
 	.global _BPMSG1165_str
 _BPMSG1165_str:
-	.pascii "AUX"
+	.pasciz "AUX"
 
 	; BPMSG1166
 	.section .text.BPMSG1166, code
 	.global _BPMSG1166_str
 _BPMSG1166_str:
-	.pascii "MODE LED"
+	.pasciz "MODE LED"
 
 	; BPMSG1167
 	.section .text.BPMSG1167, code
 	.global _BPMSG1167_str
 _BPMSG1167_str:
-	.pascii "PULLUP H"
+	.pasciz "PULLUP H"
 
 	; BPMSG1168
 	.section .text.BPMSG1168, code
 	.global _BPMSG1168_str
 _BPMSG1168_str:
-	.pascii "PULLUP L"
+	.pasciz "PULLUP L"
 
 	; BPMSG1169
 	.section .text.BPMSG1169, code
 	.global _BPMSG1169_str
 _BPMSG1169_str:
-	.pascii "VREG"
+	.pasciz "VREG"
 
 	; BPMSG1170
 	.section .text.BPMSG1170, code
 	.global _BPMSG1170_str
 _BPMSG1170_str:
-	.pascii "ADC and supply"
+	.pasciz "ADC and supply"
 
 	; BPMSG1171
 	.section .text.BPMSG1171, code
 	.global _BPMSG1171_str
 _BPMSG1171_str:
-	.pascii "5V"
+	.pasciz "5V"
 
 	; BPMSG1172
 	.section .text.BPMSG1172, code
 	.global _BPMSG1172_str
 _BPMSG1172_str:
-	.pascii "VPU"
+	.pasciz "VPU"
 
 	; BPMSG1173
 	.section .text.BPMSG1173, code
 	.global _BPMSG1173_str
 _BPMSG1173_str:
-	.pascii "3.3V"
+	.pasciz "3.3V"
 
 	; BPMSG1174
 	.section .text.BPMSG1174, code
 	.global _BPMSG1174_str
 _BPMSG1174_str:
-	.pascii "ADC"
+	.pasciz "ADC"
 
 	; BPMSG1175
 	.section .text.BPMSG1175, code
 	.global _BPMSG1175_str
 _BPMSG1175_str:
-	.pascii "Bus high"
+	.pasciz "Bus high"
 
 	; BPMSG1176
 	.section .text.BPMSG1176, code
 	.global _BPMSG1176_str
 _BPMSG1176_str:
-	.pascii "Bus Hi-Z 0"
+	.pasciz "Bus Hi-Z 0"
 
 	; BPMSG1177
 	.section .text.BPMSG1177, code
 	.global _BPMSG1177_str
 _BPMSG1177_str:
-	.pascii "Bus Hi-Z 1"
+	.pasciz "Bus Hi-Z 1"
 
 	; BPMSG1178
 	.section .text.BPMSG1178, code
 	.global _BPMSG1178_str
 _BPMSG1178_str:
-	.pascii "MODE and VREG LEDs should be on!"
+	.pasciz "MODE and VREG LEDs should be on!"
 
 	; BPMSG1179
 	.section .text.BPMSG1179, code
 	.global _BPMSG1179_str
 _BPMSG1179_str:
-	.pascii "Found "
+	.pasciz "Found "
 
 	; BPMSG1180
 	.section .text.BPMSG1180, code
 	.global _BPMSG1180_str
 _BPMSG1180_str:
-	.pascii " errors."
+	.pasciz " errors."
 
 	; BPMSG1181
 	.section .text.BPMSG1181, code
 	.global _BPMSG1181_str
 _BPMSG1181_str:
-	.pascii "MOSI"
+	.pasciz "MOSI"
 
 	; BPMSG1182
 	.section .text.BPMSG1182, code
 	.global _BPMSG1182_str
 _BPMSG1182_str:
-	.pascii "CLK"
+	.pasciz "CLK"
 
 	; BPMSG1183
 	.section .text.BPMSG1183, code
 	.global _BPMSG1183_str
 _BPMSG1183_str:
-	.pascii "MISO"
+	.pasciz "MISO"
 
 	; BPMSG1184
 	.section .text.BPMSG1184, code
 	.global _BPMSG1184_str
 _BPMSG1184_str:
-	.pascii "CS"
+	.pasciz "CS"
 
 	; BPMSG1185
 	.section .text.BPMSG1185, code
 	.global _BPMSG1185_str
 _BPMSG1185_str:
-	.pascii " OK"
+	.pasciz " OK"
 
 	; BPMSG1186
 	.section .text.BPMSG1186, code
 	.global _BPMSG1186_str
 _BPMSG1186_str:
-	.pascii " FAIL"
+	.pasciz " FAIL"
 
 	; BPMSG1194
 	.section .text.BPMSG1194, code
 	.global _BPMSG1194_str
 _BPMSG1194_str:
-	.pascii "-p "
+	.pasciz "-p "
 
 	; BPMSG1195
 	.section .text.BPMSG1195, code
 	.global _BPMSG1195_str
 _BPMSG1195_str:
-	.pascii "-f "
+	.pasciz "-f "
 
 	; BPMSG1196
 	.section .text.BPMSG1196, code
 	.global _BPMSG1196_str
 _BPMSG1196_str:
-	.pascii "*Bytes dropped*"
+	.pasciz "*Bytes dropped*"
 
 	; BPMSG1197
 	.section .text.BPMSG1197, code
 	.global _BPMSG1197_str
 _BPMSG1197_str:
-	.pascii "FAILED, NO DATA"
+	.pasciz "FAILED, NO DATA"
 
 	; BPMSG1199
 	.section .text.BPMSG1199, code
 	.global _BPMSG1199_str
 _BPMSG1199_str:
-	.pascii "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
+	.pasciz "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
 
 	; BPMSG1200
 	.section .text.BPMSG1200, code
 	.global _BPMSG1200_str
 _BPMSG1200_str:
-	.pascii "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
+	.pasciz "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
 
 	; BPMSG1201
 	.section .text.BPMSG1201, code
 	.global _BPMSG1201_str
 _BPMSG1201_str:
-	.pascii "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
+	.pasciz "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
 
 	; BPMSG1202
 	.section .text.BPMSG1202, code
 	.global _BPMSG1202_str
 _BPMSG1202_str:
-	.pascii "UART (spd brg dbp sb rxp hiz)=( "
+	.pasciz "UART (spd brg dbp sb rxp hiz)=( "
 
 	; BPMSG1203
 	.section .text.BPMSG1203, code
 	.global _BPMSG1203_str
 _BPMSG1203_str:
-	.pascii " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection"
+	.pasciz " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection"
 
 	; BPMSG1204
 	.section .text.BPMSG1204, code
 	.global _BPMSG1204_str
 _BPMSG1204_str:
-	.pascii "UART bridge"
+	.pasciz "UART bridge"
 
 	; BPMSG1206
 	.section .text.BPMSG1206, code
 	.global _BPMSG1206_str
 _BPMSG1206_str:
-	.pascii "Raw UART input"
+	.pasciz "Raw UART input"
 
 	; BPMSG1207
 	.section .text.BPMSG1207, code
 	.global _BPMSG1207_str
 _BPMSG1207_str:
-	.pascii "UART LIVE DISPLAY, } TO STOP"
+	.pasciz "UART LIVE DISPLAY, } TO STOP"
 
 	; BPMSG1208
 	.section .text.BPMSG1208, code
 	.global _BPMSG1208_str
 _BPMSG1208_str:
-	.pascii "LIVE DISPLAY STOPPED"
+	.pasciz "LIVE DISPLAY STOPPED"
 
 	; BPMSG1209
 	.section .text.BPMSG1209, code
 	.global _BPMSG1209_str
 _BPMSG1209_str:
-	.pascii "WARNING: pins not open drain (HiZ)"
+	.pasciz "WARNING: pins not open drain (HiZ)"
 
 	; BPMSG1210
 	.section .text.BPMSG1210, code
 	.global _BPMSG1210_str
 _BPMSG1210_str:
-	.pascii " REVID:"
+	.pasciz " REVID:"
 
 	; BPMSG1211
 	.section .text.BPMSG1211, code
 	.global _BPMSG1211_str
 _BPMSG1211_str:
-	.pascii "\r\nInvalid choice, try again"
+	.pasciz "\r\nInvalid choice, try again"
 
 	; BPMSG1212
 	.section .text.BPMSG1212, code
 	.global _BPMSG1212_str
 _BPMSG1212_str:
-	.pascii "ms"
+	.pasciz "ms"
 
 	; BPMSG1213
 	.section .text.BPMSG1213, code
 	.global _BPMSG1213_str
 _BPMSG1213_str:
-	.pascii "RS LOW, COMMAND MODE"
+	.pasciz "RS LOW, COMMAND MODE"
 
 	; BPMSG1214
 	.section .text.BPMSG1214, code
 	.global _BPMSG1214_str
 _BPMSG1214_str:
-	.pascii "RS HIGH, DATA MODE"
+	.pasciz "RS HIGH, DATA MODE"
 
 	; BPMSG1216
 	.section .text.BPMSG1216, code
 	.global _BPMSG1216_str
 _BPMSG1216_str:
-	.pascii "This mode requires an adapter"
+	.pasciz "This mode requires an adapter"
 
 	; BPMSG1219
 	.section .text.BPMSG1219, code
 	.global _BPMSG1219_str
 _BPMSG1219_str:
-	.pascii " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
+	.pasciz " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
 
 	; BPMSG1220
 	.section .text.BPMSG1220, code
 	.global _BPMSG1220_str
 _BPMSG1220_str:
-	.pascii "Display lines:\r\n 1. 1 \r\n 2. Multiple"
+	.pasciz "Display lines:\r\n 1. 1 \r\n 2. Multiple"
 
 	; BPMSG1221
 	.section .text.BPMSG1221, code
 	.global _BPMSG1221_str
 _BPMSG1221_str:
-	.pascii "INIT"
+	.pasciz "INIT"
 
 	; BPMSG1222
 	.section .text.BPMSG1222, code
 	.global _BPMSG1222_str
 _BPMSG1222_str:
-	.pascii "CLEAR"
+	.pasciz "CLEAR"
 
 	; BPMSG1223
 	.section .text.BPMSG1223, code
 	.global _BPMSG1223_str
 _BPMSG1223_str:
-	.pascii "CURSOR SET"
+	.pasciz "CURSOR SET"
 
 	; BPMSG1226
 	.section .text.BPMSG1226, code
 	.global _BPMSG1226_str
 _BPMSG1226_str:
-	.pascii "Pinstates:"
+	.pasciz "Pinstates:"
 
 	; BPMSG1227
 	.section .text.BPMSG1227, code
 	.global _BPMSG1227_str
 _BPMSG1227_str:
-	.pascii "GND\t3.3V\t5.0V\tADC\tVPU\tAUX\t"
+	.pasciz "GND\t3.3V\t5.0V\tADC\tVPU\tAUX\t"
 
 	; BPMSG1228
 	.section .text.BPMSG1228, code
 	.global _BPMSG1228_str
 _BPMSG1228_str:
-	.pascii "P\tP\tP\tI\tI\t"
+	.pasciz "P\tP\tP\tI\tI\t"
 
 	; BPMSG1229
 	.section .text.BPMSG1229, code
 	.global _BPMSG1229_str
 _BPMSG1229_str:
-	.pascii "-\tOWD\t-\t-"
+	.pasciz "-\tOWD\t-\t-"
 
 	; BPMSG1232
 	.section .text.BPMSG1232, code
 	.global _BPMSG1232_str
 _BPMSG1232_str:
-	.pascii "PGC\tPGD\t-\t-"
+	.pasciz "PGC\tPGD\t-\t-"
 
 	; BPMSG1233
 	.section .text.BPMSG1233, code
 	.global _BPMSG1233_str
 _BPMSG1233_str:
-	.pascii "1.(BR)\t2.(RD)\t3.(OR)\t4.(YW)\t5.(GN)\t6.(BL)\t7.(PU)\t8.(GR)\t9.(WT)\t0.(Blk)"
+	.pasciz "1.(BR)\t2.(RD)\t3.(OR)\t4.(YW)\t5.(GN)\t6.(BL)\t7.(PU)\t8.(GR)\t9.(WT)\t0.(Blk)"
 
 	; BPMSG1234
 	.section .text.BPMSG1234, code
 	.global _BPMSG1234_str
 _BPMSG1234_str:
-	.pascii "GND\t"
+	.pasciz "GND\t"
 
 	; BPMSG1237
 	.section .text.BPMSG1237, code
 	.global _BPMSG1237_str
 _BPMSG1237_str:
-	.pascii " TIMEOUT"
+	.pasciz " TIMEOUT"
 
 	; BPMSG1238
 	.section .text.BPMSG1238, code
 	.global _BPMSG1238_str
 _BPMSG1238_str:
-	.pascii " 0. Macro menu\r\n 1. Live input monitor"
+	.pasciz " 0. Macro menu\r\n 1. Live input monitor"
 
 	; BPMSG1239
 	.section .text.BPMSG1239, code
 	.global _BPMSG1239_str
 _BPMSG1239_str:
-	.pascii "Input monitor, any key exits"
+	.pasciz "Input monitor, any key exits"
 
 	; BPMSG1240
 	.section .text.BPMSG1240, code
 	.global _BPMSG1240_str
 _BPMSG1240_str:
-	.pascii " *startbit error"
+	.pasciz " *startbit error"
 
 	; BPMSG1241
 	.section .text.BPMSG1241, code
 	.global _BPMSG1241_str
 _BPMSG1241_str:
-	.pascii " *parity error"
+	.pasciz " *parity error"
 
 	; BPMSG1242
 	.section .text.BPMSG1242, code
 	.global _BPMSG1242_str
 _BPMSG1242_str:
-	.pascii " *stopbit error"
+	.pasciz " *stopbit error"
 
 	; BPMSG1243
 	.section .text.BPMSG1243, code
 	.global _BPMSG1243_str
 _BPMSG1243_str:
-	.pascii " NONE"
+	.pasciz " NONE"
 
 	; BPMSG1244
 	.section .text.BPMSG1244, code
 	.global _BPMSG1244_str
 _BPMSG1244_str:
-	.pascii " UNKNOWN ERROR"
+	.pasciz " UNKNOWN ERROR"
 
 	; BPMSG1245
 	.section .text.BPMSG1245, code
 	.global _BPMSG1245_str
 _BPMSG1245_str:
-	.pascii " autorange "
+	.pasciz " autorange "
 
 	; BPMSG1248
 	.section .text.BPMSG1248, code
 	.global _BPMSG1248_str
 _BPMSG1248_str:
-	.pascii "Raw value for BRG (MIDI=127)"
+	.pasciz "Raw value for BRG (MIDI=127)"
 
 	; BPMSG1251
 	.section .text.BPMSG1251, code
 	.global _BPMSG1251_str
 _BPMSG1251_str:
-	.pascii "Space to continue"
+	.pasciz "Space to continue"
 
 	; BPMSG1252
 	.section .text.BPMSG1252, code
 	.global _BPMSG1252_str
 _BPMSG1252_str:
-	.pascii "Number of bits read/write: "
+	.pasciz "Number of bits read/write: "
 
 	; BPMSG1254
 	.section .text.BPMSG1254, code
 	.global _BPMSG1254_str
 _BPMSG1254_str:
-	.pascii "Position in degrees"
+	.pasciz "Position in degrees"
 
 	; BPMSG1255
 	.section .text.BPMSG1255, code
 	.global _BPMSG1255_str
 _BPMSG1255_str:
-	.pascii "Servo active"
+	.pasciz "Servo active"
 
 	; BPMSG1280
 	.section .text.BPMSG1280, code
 	.global _BPMSG1280_str
 _BPMSG1280_str:
-	.pascii "Waiting activity..."
+	.pasciz "Waiting activity..."
 
 	; BPMSG1281
 	.section .text.BPMSG1281, code
 	.global _BPMSG1281_str
 _BPMSG1281_str:
-	.pascii "** Early Exit!"
+	.pasciz "** Early Exit!"
 
 	; BPMSG1282
 	.section .text.BPMSG1282, code
 	.global _BPMSG1282_str
 _BPMSG1282_str:
-	.pascii "**Baud>16m: BP Cannot measure > 16000000, Done."
+	.pasciz "**Baud>16m: BP Cannot measure > 16000000, Done."
 
 	; BPMSG1283
 	.section .text.BPMSG1283, code
 	.global _BPMSG1283_str
 _BPMSG1283_str:
-	.pascii "\n\rCalculated: \t"
+	.pasciz "\n\rCalculated: \t"
 
 	; BPMSG1284
 	.section .text.BPMSG1284, code
 	.global _BPMSG1284_str
 _BPMSG1284_str:
-	.pascii "\n\rEstimated:  \t"
+	.pasciz "\n\rEstimated:  \t"
 
 	; BPMSG1285
 	.section .text.BPMSG1285, code
 	.global _BPMSG1285_str
 _BPMSG1285_str:
-	.pascii " bps"
+	.pasciz " bps"
 
 	; HLP1000
 	.section .text.HLP1000, code
 	.global _HLP1000_str
 _HLP1000_str:
-	.pascii " General\t\t\t\t\tProtocol interaction"
+	.pasciz " General\t\t\t\t\tProtocol interaction"
 
 	; HLP1001
 	.section .text.HLP1001, code
 	.global _HLP1001_str
 _HLP1001_str:
-	.pascii " ---------------------------------------------------------------------------"
+	.pasciz " ---------------------------------------------------------------------------"
 
 	; HLP1002
 	.section .text.HLP1002, code
 	.global _HLP1002_str
 _HLP1002_str:
-	.pascii " ?\tThis help\t\t\t(0)\tList current macros"
+	.pasciz " ?\tThis help\t\t\t(0)\tList current macros"
 
 	; HLP1003
 	.section .text.HLP1003, code
 	.global _HLP1003_str
 _HLP1003_str:
-	.pascii " =X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
+	.pasciz " =X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
 
 	; HLP1004
 	.section .text.HLP1004, code
 	.global _HLP1004_str
 _HLP1004_str:
-	.pascii " ~\tSelftest\t\t\t[\tStart"
+	.pasciz " ~\tSelftest\t\t\t[\tStart"
 
 	; HLP1005
 	.section .text.HLP1005, code
 	.global _HLP1005_str
 _HLP1005_str:
-	.pascii " #\tReset the BP   \t\t\t]\tStop"
+	.pasciz " #\tReset the BP   \t\t\t]\tStop"
 
 	; HLP1006
 	.section .text.HLP1006, code
 	.global _HLP1006_str
 _HLP1006_str:
-	.pascii " $\tJump to bootloader\t\t{\tStart with read"
+	.pasciz " $\tJump to bootloader\t\t{\tStart with read"
 
 	; HLP1007
 	.section .text.HLP1007, code
 	.global _HLP1007_str
 _HLP1007_str:
-	.pascii " &/%\tDelay 1 us/ms\t\t\t}\tStop"
+	.pasciz " &/%\tDelay 1 us/ms\t\t\t}\tStop"
 
 	; HLP1008
 	.section .text.HLP1008, code
 	.global _HLP1008_str
 _HLP1008_str:
-	.pascii " a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
+	.pasciz " a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
 
 	; HLP1009
 	.section .text.HLP1009, code
 	.global _HLP1009_str
 _HLP1009_str:
-	.pascii " b\tSet baudrate\t\t\t123"
+	.pasciz " b\tSet baudrate\t\t\t123"
 
 	; HLP1010
 	.section .text.HLP1010, code
 	.global _HLP1010_str
 _HLP1010_str:
-	.pascii " c/C\tAUX assignment (aux/CS)\t\t0x123"
+	.pasciz " c/C\tAUX assignment (aux/CS)\t\t0x123"
 
 	; HLP1011
 	.section .text.HLP1011, code
 	.global _HLP1011_str
 _HLP1011_str:
-	.pascii " d/D\tMeasure ADC (once/CONT.)\t0b110\tSend value"
+	.pasciz " d/D\tMeasure ADC (once/CONT.)\t0b110\tSend value"
 
 	; HLP1012
 	.section .text.HLP1012, code
 	.global _HLP1012_str
 _HLP1012_str:
-	.pascii " f\tMeasure frequency\t\tr\tRead"
+	.pasciz " f\tMeasure frequency\t\tr\tRead"
 
 	; HLP1013
 	.section .text.HLP1013, code
 	.global _HLP1013_str
 _HLP1013_str:
-	.pascii " g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
+	.pasciz " g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
 
 	; HLP1014
 	.section .text.HLP1014, code
 	.global _HLP1014_str
 _HLP1014_str:
-	.pascii " h\tCommandhistory\t\t\t\\\tCLK lo"
+	.pasciz " h\tCommandhistory\t\t\t\\\tCLK lo"
 
 	; HLP1015
 	.section .text.HLP1015, code
 	.global _HLP1015_str
 _HLP1015_str:
-	.pascii " i\tVersioninfo/statusinfo\t\t^\tCLK tick"
+	.pasciz " i\tVersioninfo/statusinfo\t\t^\tCLK tick"
 
 	; HLP1016
 	.section .text.HLP1016, code
 	.global _HLP1016_str
 _HLP1016_str:
-	.pascii " l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
+	.pasciz " l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
 
 	; HLP1017
 	.section .text.HLP1017, code
 	.global _HLP1017_str
 _HLP1017_str:
-	.pascii " m\tChange mode\t\t\t_\tDAT lo"
+	.pasciz " m\tChange mode\t\t\t_\tDAT lo"
 
 	; HLP1018
 	.section .text.HLP1018, code
 	.global _HLP1018_str
 _HLP1018_str:
-	.pascii " o\tSet output type\t\t\t.\tDAT read"
+	.pasciz " o\tSet output type\t\t\t.\tDAT read"
 
 	; HLP1019
 	.section .text.HLP1019, code
 	.global _HLP1019_str
 _HLP1019_str:
-	.pascii " p/P\tPullup resistors (off/ON)\t!\tBit read"
+	.pasciz " p/P\tPullup resistors (off/ON)\t!\tBit read"
 
 	; HLP1020
 	.section .text.HLP1020, code
 	.global _HLP1020_str
 _HLP1020_str:
-	.pascii " s\tScript engine\t\t\t:\tRepeat e.g. r:10"
+	.pasciz " s\tScript engine\t\t\t:\tRepeat e.g. r:10"
 
 	; HLP1021
 	.section .text.HLP1021, code
 	.global _HLP1021_str
 _HLP1021_str:
-	.pascii " v\tShow volts/states\t\t.\tBits to read/write e.g. 0x55.2"
+	.pasciz " v\tShow volts/states\t\t.\tBits to read/write e.g. 0x55.2"
 
 	; HLP1022
 	.section .text.HLP1022, code
 	.global _HLP1022_str
 _HLP1022_str:
-	.pascii " w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
+	.pasciz " w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
 
 	; MSG_1WIRE_MODE_IDENTIFIER
 	.section .text.MSG_1WIRE_MODE_IDENTIFIER, code
 	.global _MSG_1WIRE_MODE_IDENTIFIER_str
 _MSG_1WIRE_MODE_IDENTIFIER_str:
-	.pascii "1W01"
+	.pasciz "1W01"
 
 	; MSG_1WIRE_NEXT_CLOCK_ALERT
 	.section .text.MSG_1WIRE_NEXT_CLOCK_ALERT, code
 	.global _MSG_1WIRE_NEXT_CLOCK_ALERT_str
 _MSG_1WIRE_NEXT_CLOCK_ALERT_str:
-	.pascii " *next clock (^) will use this value"
+	.pasciz " *next clock (^) will use this value"
 
 	; MSG_1WIRE_SPEED_PROMPT
 	.section .text.MSG_1WIRE_SPEED_PROMPT, code
 	.global _MSG_1WIRE_SPEED_PROMPT_str
 _MSG_1WIRE_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
+	.pasciz "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
 
 	; MSG_ACK
 	.section .text.MSG_ACK, code
 	.global _MSG_ACK_str
 _MSG_ACK_str:
-	.pascii "ACK"
+	.pasciz "ACK"
 
 	; MSG_ANY_KEY_TO_EXIT_PROMPT
 	.section .text.MSG_ANY_KEY_TO_EXIT_PROMPT, code
 	.global _MSG_ANY_KEY_TO_EXIT_PROMPT_str
 _MSG_ANY_KEY_TO_EXIT_PROMPT_str:
-	.pascii "Any key to exit"
+	.pasciz "Any key to exit"
 
 	; MSG_BASE_CONVERTER_EQUAL_SIGN
 	.section .text.MSG_BASE_CONVERTER_EQUAL_SIGN, code
 	.global _MSG_BASE_CONVERTER_EQUAL_SIGN_str
 _MSG_BASE_CONVERTER_EQUAL_SIGN_str:
-	.pascii " = "
+	.pasciz " = "
 
 	; MSG_BBIO_MODE_IDENTIFIER
 	.section .text.MSG_BBIO_MODE_IDENTIFIER, code
 	.global _MSG_BBIO_MODE_IDENTIFIER_str
 _MSG_BBIO_MODE_IDENTIFIER_str:
-	.pascii "BBIO1"
+	.pasciz "BBIO1"
 
 	; MSG_BINARY_NUMBER_PREFIX
 	.section .text.MSG_BINARY_NUMBER_PREFIX, code
 	.global _MSG_BINARY_NUMBER_PREFIX_str
 _MSG_BINARY_NUMBER_PREFIX_str:
-	.pascii "0b"
+	.pasciz "0b"
 
 	; MSG_CHIP_IDENTIFIER_CLONE
 	.section .text.MSG_CHIP_IDENTIFIER_CLONE, code
 	.global _MSG_CHIP_IDENTIFIER_CLONE_str
 _MSG_CHIP_IDENTIFIER_CLONE_str:
-	.pascii " clone w/different PIC"
+	.pasciz " clone w/different PIC"
 
 	; MSG_CHIP_REVISION_A3
 	.section .text.MSG_CHIP_REVISION_A3, code
 	.global _MSG_CHIP_REVISION_A3_str
 _MSG_CHIP_REVISION_A3_str:
-	.pascii "A3"
+	.pasciz "A3"
 
 	; MSG_CHIP_REVISION_B4
 	.section .text.MSG_CHIP_REVISION_B4, code
 	.global _MSG_CHIP_REVISION_B4_str
 _MSG_CHIP_REVISION_B4_str:
-	.pascii "B4"
+	.pasciz "B4"
 
 	; MSG_CHIP_REVISION_B5
 	.section .text.MSG_CHIP_REVISION_B5, code
 	.global _MSG_CHIP_REVISION_B5_str
 _MSG_CHIP_REVISION_B5_str:
-	.pascii "B5"
+	.pasciz "B5"
 
 	; MSG_CHIP_REVISION_B8
 	.section .text.MSG_CHIP_REVISION_B8, code
 	.global _MSG_CHIP_REVISION_B8_str
 _MSG_CHIP_REVISION_B8_str:
-	.pascii "B8"
+	.pasciz "B8"
 
 	; MSG_CHIP_REVISION_ID_BEGIN
 	.section .text.MSG_CHIP_REVISION_ID_BEGIN, code
 	.global _MSG_CHIP_REVISION_ID_BEGIN_str
 _MSG_CHIP_REVISION_ID_BEGIN_str:
-	.pascii " (24FJ64GA00 "
+	.pasciz " (24FJ64GA00 "
 
 	; MSG_CHIP_REVISION_ID_END_2
 	.section .text.MSG_CHIP_REVISION_ID_END_2, code
 	.global _MSG_CHIP_REVISION_ID_END_2_str
 _MSG_CHIP_REVISION_ID_END_2_str:
-	.pascii "2 "
+	.pasciz "2 "
 
 	; MSG_CHIP_REVISION_ID_END_4
 	.section .text.MSG_CHIP_REVISION_ID_END_4, code
 	.global _MSG_CHIP_REVISION_ID_END_4_str
 _MSG_CHIP_REVISION_ID_END_4_str:
-	.pascii "4 "
+	.pasciz "4 "
 
 	; MSG_CHIP_REVISION_UNKNOWN
 	.section .text.MSG_CHIP_REVISION_UNKNOWN, code
 	.global _MSG_CHIP_REVISION_UNKNOWN_str
 _MSG_CHIP_REVISION_UNKNOWN_str:
-	.pascii "UNK"
+	.pasciz "UNK"
 
 	; MSG_CLUTCH_DISENGAGED
 	.section .text.MSG_CLUTCH_DISENGAGED, code
 	.global _MSG_CLUTCH_DISENGAGED_str
 _MSG_CLUTCH_DISENGAGED_str:
-	.pascii "Clutch disengaged!!!"
+	.pasciz "Clutch disengaged!!!"
 
 	; MSG_CLUTCH_ENGAGED
 	.section .text.MSG_CLUTCH_ENGAGED, code
 	.global _MSG_CLUTCH_ENGAGED_str
 _MSG_CLUTCH_ENGAGED_str:
-	.pascii "Clutch engaged!!!"
+	.pasciz "Clutch engaged!!!"
 
 	; MSG_FINISH_SETUP_PROMPT
 	.section .text.MSG_FINISH_SETUP_PROMPT, code
 	.global _MSG_FINISH_SETUP_PROMPT_str
 _MSG_FINISH_SETUP_PROMPT_str:
-	.pascii "To finish setup, start up the power supplies with command 'W'"
+	.pasciz "To finish setup, start up the power supplies with command 'W'"
 
 	; MSG_HEXADECIMAL_NUMBER_PREFIX
 	.section .text.MSG_HEXADECIMAL_NUMBER_PREFIX, code
 	.global _MSG_HEXADECIMAL_NUMBER_PREFIX_str
 _MSG_HEXADECIMAL_NUMBER_PREFIX_str:
-	.pascii "0x"
+	.pasciz "0x"
 
 	; MSG_I2C_MODE_IDENTIFIER
 	.section .text.MSG_I2C_MODE_IDENTIFIER, code
 	.global _MSG_I2C_MODE_IDENTIFIER_str
 _MSG_I2C_MODE_IDENTIFIER_str:
-	.pascii "I2C1"
+	.pasciz "I2C1"
 
 	; MSG_I2C_PINS_STATE
 	.section .text.MSG_I2C_PINS_STATE, code
 	.global _MSG_I2C_PINS_STATE_str
 _MSG_I2C_PINS_STATE_str:
-	.pascii "SCL\tSDA\t-\t-"
+	.pasciz "SCL\tSDA\t-\t-"
 
 	; MSG_I2C_READ_ADDRESS_END
 	.section .text.MSG_I2C_READ_ADDRESS_END, code
 	.global _MSG_I2C_READ_ADDRESS_END_str
 _MSG_I2C_READ_ADDRESS_END_str:
-	.pascii " R) "
+	.pasciz " R) "
 
 	; MSG_I2C_START_BIT
 	.section .text.MSG_I2C_START_BIT, code
 	.global _MSG_I2C_START_BIT_str
 _MSG_I2C_START_BIT_str:
-	.pascii "I2C START BIT"
+	.pasciz "I2C START BIT"
 
 	; MSG_I2C_STOP_BIT
 	.section .text.MSG_I2C_STOP_BIT, code
 	.global _MSG_I2C_STOP_BIT_str
 _MSG_I2C_STOP_BIT_str:
-	.pascii "I2C STOP BIT"
+	.pasciz "I2C STOP BIT"
 
 	; MSG_I2C_WRITE_ADDRESS_END
 	.section .text.MSG_I2C_WRITE_ADDRESS_END, code
 	.global _MSG_I2C_WRITE_ADDRESS_END_str
 _MSG_I2C_WRITE_ADDRESS_END_str:
-	.pascii " W) "
+	.pasciz " W) "
 
 	; MSG_MODE_HEADER_END
 	.section .text.MSG_MODE_HEADER_END, code
 	.global _MSG_MODE_HEADER_END_str
 _MSG_MODE_HEADER_END_str:
-	.pascii " )"
+	.pasciz " )"
 
 	; MSG_NACK
 	.section .text.MSG_NACK, code
 	.global _MSG_NACK_str
 _MSG_NACK_str:
-	.pascii "NACK"
+	.pasciz "NACK"
 
 	; MSG_NO_VOLTAGE_ON_PULLUP_PIN
 	.section .text.MSG_NO_VOLTAGE_ON_PULLUP_PIN, code
 	.global _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str
 _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str:
-	.pascii "Warning: no voltage on Vpullup pin"
+	.pasciz "Warning: no voltage on Vpullup pin"
 
 	; MSG_OPENOCD_MODE_IDENTIFIER
 	.section .text.MSG_OPENOCD_MODE_IDENTIFIER, code
 	.global _MSG_OPENOCD_MODE_IDENTIFIER_str
 _MSG_OPENOCD_MODE_IDENTIFIER_str:
-	.pascii "OCD1"
+	.pasciz "OCD1"
 
 	; MSG_PIC_MODE_IDENTIFIER
 	.section .text.MSG_PIC_MODE_IDENTIFIER, code
 	.global _MSG_PIC_MODE_IDENTIFIER_str
 _MSG_PIC_MODE_IDENTIFIER_str:
-	.pascii "PIC1"
+	.pasciz "PIC1"
 
 	; MSG_PIC_UNKNOWN_MODE
 	.section .text.MSG_PIC_UNKNOWN_MODE, code
 	.global _MSG_PIC_UNKNOWN_MODE_str
 _MSG_PIC_UNKNOWN_MODE_str:
-	.pascii "unknown mode"
+	.pasciz "unknown mode"
 
 	; MSG_PIN_OUTPUT_TYPE_PROMPT
 	.section .text.MSG_PIN_OUTPUT_TYPE_PROMPT, code
 	.global _MSG_PIN_OUTPUT_TYPE_PROMPT_str
 _MSG_PIN_OUTPUT_TYPE_PROMPT_str:
-	.pascii "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
+	.pasciz "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
 
 	; MSG_PWM_FREQUENCY_TOO_LOW
 	.section .text.MSG_PWM_FREQUENCY_TOO_LOW, code
 	.global _MSG_PWM_FREQUENCY_TOO_LOW_str
 _MSG_PWM_FREQUENCY_TOO_LOW_str:
-	.pascii "Frequencies < 1Hz are not supported."
+	.pasciz "Frequencies < 1Hz are not supported."
 
 	; MSG_PWM_HZ_MARKER
 	.section .text.MSG_PWM_HZ_MARKER, code
 	.global _MSG_PWM_HZ_MARKER_str
 _MSG_PWM_HZ_MARKER_str:
-	.pascii " Hz"
+	.pasciz " Hz"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str
 _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str:
-	.pascii "Data units: "
+	.pasciz "Data units: "
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str
 _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str:
-	.pascii "no indication"
+	.pasciz "no indication"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str
 _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str:
-	.pascii "Data unit length (bits): "
+	.pasciz "Data unit length (bits): "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str:
-	.pascii "2 wire"
+	.pasciz "2 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str:
-	.pascii "3 wire"
+	.pasciz "3 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str:
-	.pascii "Protocol: "
+	.pasciz "Protocol: "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str:
-	.pascii "serial"
+	.pasciz "serial"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str:
-	.pascii "unknown"
+	.pasciz "unknown"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str:
-	.pascii "Read type: "
+	.pasciz "Read type: "
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_TO_END
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_TO_END, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str:
-	.pascii "to end"
+	.pasciz "to end"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str:
-	.pascii "variable length"
+	.pasciz "variable length"
 
 	; MSG_RAW2WIRE_ATR_REPLY_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_REPLY_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_REPLY_HEADER_str
 _MSG_RAW2WIRE_ATR_REPLY_HEADER_str:
-	.pascii "ISO 7816-3 reply (uses current LSB setting): "
+	.pasciz "ISO 7816-3 reply (uses current LSB setting): "
 
 	; MSG_RAW2WIRE_ATR_RFU
 	.section .text.MSG_RAW2WIRE_ATR_RFU, code
 	.global _MSG_RAW2WIRE_ATR_RFU_str
 _MSG_RAW2WIRE_ATR_RFU_str:
-	.pascii "RFU"
+	.pasciz "RFU"
 
 	; MSG_RAW2WIRE_ATR_TRIGGER_INFO
 	.section .text.MSG_RAW2WIRE_ATR_TRIGGER_INFO, code
 	.global _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str
 _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str:
-	.pascii "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
+	.pasciz "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
 
 	; MSG_RAW2WIRE_I2C_START
 	.section .text.MSG_RAW2WIRE_I2C_START, code
 	.global _MSG_RAW2WIRE_I2C_START_str
 _MSG_RAW2WIRE_I2C_START_str:
-	.pascii "(\\-/_\\-)"
+	.pasciz "(\\-/_\\-)"
 
 	; MSG_RAW2WIRE_I2C_STOP
 	.section .text.MSG_RAW2WIRE_I2C_STOP, code
 	.global _MSG_RAW2WIRE_I2C_STOP_str
 _MSG_RAW2WIRE_I2C_STOP_str:
-	.pascii "(\\_/-)"
+	.pasciz "(\\_/-)"
 
 	; MSG_RAW2WIRE_MACRO_MENU
 	.section .text.MSG_RAW2WIRE_MACRO_MENU, code
 	.global _MSG_RAW2WIRE_MACRO_MENU_str
 _MSG_RAW2WIRE_MACRO_MENU_str:
-	.pascii " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
+	.pasciz " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
 
 	; MSG_RAW2WIRE_MODE_HEADER
 	.section .text.MSG_RAW2WIRE_MODE_HEADER, code
 	.global _MSG_RAW2WIRE_MODE_HEADER_str
 _MSG_RAW2WIRE_MODE_HEADER_str:
-	.pascii "R2W (spd hiz)=( "
+	.pasciz "R2W (spd hiz)=( "
 
 	; MSG_RAW3WIRE_MODE_HEADER
 	.section .text.MSG_RAW3WIRE_MODE_HEADER, code
 	.global _MSG_RAW3WIRE_MODE_HEADER_str
 _MSG_RAW3WIRE_MODE_HEADER_str:
-	.pascii "R3W (spd csl hiz)=( "
+	.pasciz "R3W (spd csl hiz)=( "
 
 	; MSG_RAW_BRG_VALUE_INPUT
 	.section .text.MSG_RAW_BRG_VALUE_INPUT, code
 	.global _MSG_RAW_BRG_VALUE_INPUT_str
 _MSG_RAW_BRG_VALUE_INPUT_str:
-	.pascii "Enter raw value for BRG"
+	.pasciz "Enter raw value for BRG"
 
 	; MSG_RAW_MODE_IDENTIFIER
 	.section .text.MSG_RAW_MODE_IDENTIFIER, code
 	.global _MSG_RAW_MODE_IDENTIFIER_str
 _MSG_RAW_MODE_IDENTIFIER_str:
-	.pascii "RAW1"
+	.pasciz "RAW1"
 
 	; MSG_SNIFFER_MESSAGE
 	.section .text.MSG_SNIFFER_MESSAGE, code
 	.global _MSG_SNIFFER_MESSAGE_str
 _MSG_SNIFFER_MESSAGE_str:
-	.pascii "Sniffer"
+	.pasciz "Sniffer"
 
 	; MSG_SOFTWARE_MODE_SPEED_PROMPT
 	.section .text.MSG_SOFTWARE_MODE_SPEED_PROMPT, code
 	.global _MSG_SOFTWARE_MODE_SPEED_PROMPT_str
 _MSG_SOFTWARE_MODE_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
+	.pasciz "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
 
 	; MSG_SPI_COULD_NOT_KEEP_UP
 	.section .text.MSG_SPI_COULD_NOT_KEEP_UP, code
 	.global _MSG_SPI_COULD_NOT_KEEP_UP_str
 _MSG_SPI_COULD_NOT_KEEP_UP_str:
-	.pascii "Couldn't keep up"
+	.pasciz "Couldn't keep up"
 
 	; MSG_SPI_CS_DISABLED
 	.section .text.MSG_SPI_CS_DISABLED, code
 	.global _MSG_SPI_CS_DISABLED_str
 _MSG_SPI_CS_DISABLED_str:
-	.pascii "CS DISABLED"
+	.pasciz "CS DISABLED"
 
 	; MSG_SPI_CS_ENABLED
 	.section .text.MSG_SPI_CS_ENABLED, code
 	.global _MSG_SPI_CS_ENABLED_str
 _MSG_SPI_CS_ENABLED_str:
-	.pascii "CS ENABLED"
+	.pasciz "CS ENABLED"
 
 	; MSG_SPI_CS_MODE_PROMPT
 	.section .text.MSG_SPI_CS_MODE_PROMPT, code
 	.global _MSG_SPI_CS_MODE_PROMPT_str
 _MSG_SPI_CS_MODE_PROMPT_str:
-	.pascii "CS:\r\n 1. CS\r\n 2. /CS *default"
+	.pasciz "CS:\r\n 1. CS\r\n 2. /CS *default"
 
 	; MSG_SPI_EDGE_PROMPT
 	.section .text.MSG_SPI_EDGE_PROMPT, code
 	.global _MSG_SPI_EDGE_PROMPT_str
 _MSG_SPI_EDGE_PROMPT_str:
-	.pascii "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
+	.pasciz "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
 
 	; MSG_SPI_MACRO_MENU
 	.section .text.MSG_SPI_MACRO_MENU, code
 	.global _MSG_SPI_MACRO_MENU_str
 _MSG_SPI_MACRO_MENU_str:
-	.pascii " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic\r\n10.Set clock idle low\r\n11.Set clock idle high\r\n12.Set edge idle to active\r\n13.Set edge active to idle\r\n14.Sample phase on middle\r\n15.Sample phase on end"
+	.pasciz " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic\r\n10.Set clock idle low\r\n11.Set clock idle high\r\n12.Set edge idle to active\r\n13.Set edge active to idle\r\n14.Sample phase on middle\r\n15.Sample phase on end"
 
 	; MSG_SPI_MODE_HEADER_START
 	.section .text.MSG_SPI_MODE_HEADER_START, code
 	.global _MSG_SPI_MODE_HEADER_START_str
 _MSG_SPI_MODE_HEADER_START_str:
-	.pascii "SPI (spd ckp ske smp csl hiz)=( "
+	.pasciz "SPI (spd ckp ske smp csl hiz)=( "
 
 	; MSG_SPI_MODE_IDENTIFIER
 	.section .text.MSG_SPI_MODE_IDENTIFIER, code
 	.global _MSG_SPI_MODE_IDENTIFIER_str
 _MSG_SPI_MODE_IDENTIFIER_str:
-	.pascii "SPI1"
+	.pasciz "SPI1"
 
 	; MSG_SPI_PINS_STATE
 	.section .text.MSG_SPI_PINS_STATE, code
 	.global _MSG_SPI_PINS_STATE_str
 _MSG_SPI_PINS_STATE_str:
-	.pascii "CLK\tMOSI\tCS\tMISO"
+	.pasciz "CLK\tMOSI\tCS\tMISO"
 
 	; MSG_SPI_POLARITY_PROMPT
 	.section .text.MSG_SPI_POLARITY_PROMPT, code
 	.global _MSG_SPI_POLARITY_PROMPT_str
 _MSG_SPI_POLARITY_PROMPT_str:
-	.pascii "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
+	.pasciz "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
 
 	; MSG_SPI_SAMPLE_PROMPT
 	.section .text.MSG_SPI_SAMPLE_PROMPT, code
 	.global _MSG_SPI_SAMPLE_PROMPT_str
 _MSG_SPI_SAMPLE_PROMPT_str:
-	.pascii "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
+	.pasciz "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
 
 	; MSG_SPI_SPEED_PROMPT
 	.section .text.MSG_SPI_SPEED_PROMPT, code
 	.global _MSG_SPI_SPEED_PROMPT_str
 _MSG_SPI_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
+	.pasciz "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
 
 	; MSG_UART_MODE_IDENTIFIER
 	.section .text.MSG_UART_MODE_IDENTIFIER, code
 	.global _MSG_UART_MODE_IDENTIFIER_str
 _MSG_UART_MODE_IDENTIFIER_str:
-	.pascii "ART1"
+	.pasciz "ART1"
 
 	; MSG_UART_PINS_STATE
 	.section .text.MSG_UART_PINS_STATE, code
 	.global _MSG_UART_PINS_STATE_str
 _MSG_UART_PINS_STATE_str:
-	.pascii "-\tTxD\t-\tRxD"
+	.pasciz "-\tTxD\t-\tRxD"
 
 	; MSG_UART_POSSIBLE_OVERFLOW
 	.section .text.MSG_UART_POSSIBLE_OVERFLOW, code
 	.global _MSG_UART_POSSIBLE_OVERFLOW_str
 _MSG_UART_POSSIBLE_OVERFLOW_str:
-	.pascii "WARNING: Possible buffer overflow"
+	.pasciz "WARNING: Possible buffer overflow"
 
 	; MSG_UART_RESET_TO_EXIT
 	.section .text.MSG_UART_RESET_TO_EXIT, code
 	.global _MSG_UART_RESET_TO_EXIT_str
 _MSG_UART_RESET_TO_EXIT_str:
-	.pascii "Reset to exit"
+	.pasciz "Reset to exit"
 
 	; MSG_UNKNOWN_MACRO_ERROR
 	.section .text.MSG_UNKNOWN_MACRO_ERROR, code
 	.global _MSG_UNKNOWN_MACRO_ERROR_str
 _MSG_UNKNOWN_MACRO_ERROR_str:
-	.pascii "Unknown macro, try ? or (0) for help"
+	.pasciz "Unknown macro, try ? or (0) for help"
 
 	; MSG_VREG_TOO_LOW
 	.section .text.MSG_VREG_TOO_LOW, code
 	.global _MSG_VREG_TOO_LOW_str
 _MSG_VREG_TOO_LOW_str:
-	.pascii "VREG too low, is there a short?"
+	.pasciz "VREG too low, is there a short?"
 

--- a/Firmware/messages_v4.h
+++ b/Firmware/messages_v4.h
@@ -2,602 +2,602 @@
 #define BP_MESSAGES_V4_H
 
 void BPMSG1004_str(void);
-#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str), 41)
+#define BPMSG1004 bp_message_write_line(__builtin_tbladdress(BPMSG1004_str))
 void BPMSG1005_str(void);
-#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str), 14)
+#define BPMSG1005 bp_message_write_buffer(__builtin_tbladdress(BPMSG1005_str))
 void BPMSG1006_str(void);
-#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str), 13)
+#define BPMSG1006 bp_message_write_line(__builtin_tbladdress(BPMSG1006_str))
 void BPMSG1007_str(void);
-#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str), 23)
+#define BPMSG1007 bp_message_write_line(__builtin_tbladdress(BPMSG1007_str))
 void BPMSG1008_str(void);
-#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str), 6)
+#define BPMSG1008 bp_message_write_buffer(__builtin_tbladdress(BPMSG1008_str))
 void BPMSG1009_str(void);
-#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str), 211)
+#define BPMSG1009 bp_message_write_line(__builtin_tbladdress(BPMSG1009_str))
 void BPMSG1010_str(void);
-#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str), 19)
+#define BPMSG1010 bp_message_write_line(__builtin_tbladdress(BPMSG1010_str))
 void BPMSG1011_str(void);
-#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str), 13)
+#define BPMSG1011 bp_message_write_line(__builtin_tbladdress(BPMSG1011_str))
 void BPMSG1012_str(void);
-#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str), 43)
+#define BPMSG1012 bp_message_write_line(__builtin_tbladdress(BPMSG1012_str))
 void BPMSG1013_str(void);
-#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str), 17)
+#define BPMSG1013 bp_message_write_buffer(__builtin_tbladdress(BPMSG1013_str))
 void BPMSG1014_str(void);
-#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str), 16)
+#define BPMSG1014 bp_message_write_line(__builtin_tbladdress(BPMSG1014_str))
 void BPMSG1015_str(void);
-#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str), 15)
+#define BPMSG1015 bp_message_write_line(__builtin_tbladdress(BPMSG1015_str))
 void BPMSG1017_str(void);
-#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str), 10)
+#define BPMSG1017 bp_message_write_buffer(__builtin_tbladdress(BPMSG1017_str))
 void BPMSG1019_str(void);
-#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str), 9)
+#define BPMSG1019 bp_message_write_buffer(__builtin_tbladdress(BPMSG1019_str))
 void BPMSG1020_str(void);
-#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str), 21)
+#define BPMSG1020 bp_message_write_buffer(__builtin_tbladdress(BPMSG1020_str))
 void BPMSG1021_str(void);
-#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str), 20)
+#define BPMSG1021 bp_message_write_buffer(__builtin_tbladdress(BPMSG1021_str))
 void BPMSG1022_str(void);
-#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str), 27)
+#define BPMSG1022 bp_message_write_buffer(__builtin_tbladdress(BPMSG1022_str))
 void BPMSG1023_str(void);
-#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str), 26)
+#define BPMSG1023 bp_message_write_buffer(__builtin_tbladdress(BPMSG1023_str))
 void BPMSG1024_str(void);
-#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str), 21)
+#define BPMSG1024 bp_message_write_buffer(__builtin_tbladdress(BPMSG1024_str))
 void BPMSG1025_str(void);
-#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str), 24)
+#define BPMSG1025 bp_message_write_buffer(__builtin_tbladdress(BPMSG1025_str))
 void BPMSG1026_str(void);
-#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str), 16)
+#define BPMSG1026 bp_message_write_buffer(__builtin_tbladdress(BPMSG1026_str))
 void BPMSG1027_str(void);
-#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str), 14)
+#define BPMSG1027 bp_message_write_buffer(__builtin_tbladdress(BPMSG1027_str))
 void BPMSG1028_str(void);
-#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str), 12)
+#define BPMSG1028 bp_message_write_line(__builtin_tbladdress(BPMSG1028_str))
 void BPMSG1029_str(void);
-#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str), 17)
+#define BPMSG1029 bp_message_write_line(__builtin_tbladdress(BPMSG1029_str))
 void BPMSG1030_str(void);
-#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str), 17)
+#define BPMSG1030 bp_message_write_buffer(__builtin_tbladdress(BPMSG1030_str))
 void BPMSG1033_str(void);
-#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str), 16)
+#define BPMSG1033 bp_message_write_buffer(__builtin_tbladdress(BPMSG1033_str))
 void BPMSG1034_str(void);
-#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str), 10)
+#define BPMSG1034 bp_message_write_line(__builtin_tbladdress(BPMSG1034_str))
 void BPMSG1037_str(void);
-#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str), 31)
+#define BPMSG1037 bp_message_write_line(__builtin_tbladdress(BPMSG1037_str))
 void BPMSG1038_str(void);
-#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str), 15)
+#define BPMSG1038 bp_message_write_buffer(__builtin_tbladdress(BPMSG1038_str))
 void BPMSG1039_str(void);
-#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str), 14)
+#define BPMSG1039 bp_message_write_buffer(__builtin_tbladdress(BPMSG1039_str))
 void BPMSG1040_str(void);
-#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str), 8)
+#define BPMSG1040 bp_message_write_line(__builtin_tbladdress(BPMSG1040_str))
 void BPMSG1041_str(void);
-#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str), 7)
+#define BPMSG1041 bp_message_write_line(__builtin_tbladdress(BPMSG1041_str))
 void BPMSG1042_str(void);
-#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str), 14)
+#define BPMSG1042 bp_message_write_line(__builtin_tbladdress(BPMSG1042_str))
 void BPMSG1044_str(void);
-#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str), 15)
+#define BPMSG1044 bp_message_write_buffer(__builtin_tbladdress(BPMSG1044_str))
 void BPMSG1045_str(void);
-#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str), 1)
+#define BPMSG1045 bp_message_write_buffer(__builtin_tbladdress(BPMSG1045_str))
 void BPMSG1047_str(void);
-#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str), 6)
+#define BPMSG1047 bp_message_write_buffer(__builtin_tbladdress(BPMSG1047_str))
 void BPMSG1048_str(void);
-#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str), 8)
+#define BPMSG1048 bp_message_write_buffer(__builtin_tbladdress(BPMSG1048_str))
 void BPMSG1049_str(void);
-#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str), 11)
+#define BPMSG1049 bp_message_write_buffer(__builtin_tbladdress(BPMSG1049_str))
 void BPMSG1050_str(void);
-#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str), 7)
+#define BPMSG1050 bp_message_write_line(__builtin_tbladdress(BPMSG1050_str))
 void BPMSG1051_str(void);
-#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str), 9)
+#define BPMSG1051 bp_message_write_line(__builtin_tbladdress(BPMSG1051_str))
 void BPMSG1052_str(void);
-#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str), 12)
+#define BPMSG1052 bp_message_write_line(__builtin_tbladdress(BPMSG1052_str))
 void BPMSG1053_str(void);
-#define BPMSG1053 bp_message_write_line(__builtin_tbladdress(BPMSG1053_str), 9)
+#define BPMSG1053 bp_message_write_line(__builtin_tbladdress(BPMSG1053_str))
 void BPMSG1054_str(void);
-#define BPMSG1054 bp_message_write_buffer(__builtin_tbladdress(BPMSG1054_str), 7)
+#define BPMSG1054 bp_message_write_buffer(__builtin_tbladdress(BPMSG1054_str))
 void BPMSG1055_str(void);
-#define BPMSG1055 bp_message_write_line(__builtin_tbladdress(BPMSG1055_str), 4)
+#define BPMSG1055 bp_message_write_line(__builtin_tbladdress(BPMSG1055_str))
 void BPMSG1056_str(void);
-#define BPMSG1056 bp_message_write_buffer(__builtin_tbladdress(BPMSG1056_str), 15)
+#define BPMSG1056 bp_message_write_buffer(__builtin_tbladdress(BPMSG1056_str))
 void BPMSG1057_str(void);
-#define BPMSG1057 bp_message_write_line(__builtin_tbladdress(BPMSG1057_str), 12)
+#define BPMSG1057 bp_message_write_line(__builtin_tbladdress(BPMSG1057_str))
 void BPMSG1058_str(void);
-#define BPMSG1058 bp_message_write_buffer(__builtin_tbladdress(BPMSG1058_str), 18)
+#define BPMSG1058 bp_message_write_buffer(__builtin_tbladdress(BPMSG1058_str))
 void BPMSG1059_str(void);
-#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str), 33)
+#define BPMSG1059 bp_message_write_line(__builtin_tbladdress(BPMSG1059_str))
 void BPMSG1064_str(void);
-#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str), 37)
+#define BPMSG1064 bp_message_write_line(__builtin_tbladdress(BPMSG1064_str))
 void BPMSG1067_str(void);
-#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str), 44)
+#define BPMSG1067 bp_message_write_buffer(__builtin_tbladdress(BPMSG1067_str))
 void BPMSG1068_str(void);
-#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str), 16)
+#define BPMSG1068 bp_message_write_buffer(__builtin_tbladdress(BPMSG1068_str))
 void BPMSG1069_str(void);
-#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str), 123)
+#define BPMSG1069 bp_message_write_buffer(__builtin_tbladdress(BPMSG1069_str))
 void BPMSG1070_str(void);
-#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str), 46)
+#define BPMSG1070 bp_message_write_line(__builtin_tbladdress(BPMSG1070_str))
 void BPMSG1072_str(void);
-#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str), 34)
+#define BPMSG1072 bp_message_write_line(__builtin_tbladdress(BPMSG1072_str))
 void BPMSG1073_str(void);
-#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str), 6)
+#define BPMSG1073 bp_message_write_line(__builtin_tbladdress(BPMSG1073_str))
 void BPMSG1074_str(void);
-#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str), 14)
+#define BPMSG1074 bp_message_write_buffer(__builtin_tbladdress(BPMSG1074_str))
 void BPMSG1075_str(void);
-#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str), 3)
+#define BPMSG1075 bp_message_write_buffer(__builtin_tbladdress(BPMSG1075_str))
 void BPMSG1076_str(void);
-#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str), 3)
+#define BPMSG1076 bp_message_write_line(__builtin_tbladdress(BPMSG1076_str))
 void BPMSG1077_str(void);
-#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str), 7)
+#define BPMSG1077 bp_message_write_line(__builtin_tbladdress(BPMSG1077_str))
 void BPMSG1078_str(void);
-#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str), 12)
+#define BPMSG1078 bp_message_write_line(__builtin_tbladdress(BPMSG1078_str))
 void BPMSG1079_str(void);
-#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str), 13)
+#define BPMSG1079 bp_message_write_line(__builtin_tbladdress(BPMSG1079_str))
 void BPMSG1080_str(void);
-#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str), 8)
+#define BPMSG1080 bp_message_write_buffer(__builtin_tbladdress(BPMSG1080_str))
 void BPMSG1081_str(void);
-#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str), 7)
+#define BPMSG1081 bp_message_write_buffer(__builtin_tbladdress(BPMSG1081_str))
 void BPMSG1082_str(void);
-#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str), 21)
+#define BPMSG1082 bp_message_write_line(__builtin_tbladdress(BPMSG1082_str))
 void BPMSG1083_str(void);
-#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str), 32)
+#define BPMSG1083 bp_message_write_line(__builtin_tbladdress(BPMSG1083_str))
 void BPMSG1084_str(void);
-#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str), 7)
+#define BPMSG1084 bp_message_write_buffer(__builtin_tbladdress(BPMSG1084_str))
 void BPMSG1085_str(void);
-#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str), 5)
+#define BPMSG1085 bp_message_write_line(__builtin_tbladdress(BPMSG1085_str))
 void BPMSG1086_str(void);
-#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str), 22)
+#define BPMSG1086 bp_message_write_line(__builtin_tbladdress(BPMSG1086_str))
 void BPMSG1087_str(void);
-#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str), 21)
+#define BPMSG1087 bp_message_write_line(__builtin_tbladdress(BPMSG1087_str))
 void BPMSG1088_str(void);
-#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str), 29)
+#define BPMSG1088 bp_message_write_line(__builtin_tbladdress(BPMSG1088_str))
 void BPMSG1089_str(void);
-#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str), 21)
+#define BPMSG1089 bp_message_write_buffer(__builtin_tbladdress(BPMSG1089_str))
 void BPMSG1091_str(void);
-#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str), 20)
+#define BPMSG1091 bp_message_write_buffer(__builtin_tbladdress(BPMSG1091_str))
 void BPMSG1092_str(void);
-#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str), 26)
+#define BPMSG1092 bp_message_write_line(__builtin_tbladdress(BPMSG1092_str))
 void BPMSG1093_str(void);
-#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str), 5)
+#define BPMSG1093 bp_message_write_line(__builtin_tbladdress(BPMSG1093_str))
 void BPMSG1094_str(void);
-#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str), 10)
+#define BPMSG1094 bp_message_write_line(__builtin_tbladdress(BPMSG1094_str))
 void BPMSG1095_str(void);
-#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str), 22)
+#define BPMSG1095 bp_message_write_buffer(__builtin_tbladdress(BPMSG1095_str))
 void BPMSG1096_str(void);
-#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str), 17)
+#define BPMSG1096 bp_message_write_buffer(__builtin_tbladdress(BPMSG1096_str))
 void BPMSG1097_str(void);
-#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str), 18)
+#define BPMSG1097 bp_message_write_buffer(__builtin_tbladdress(BPMSG1097_str))
 void BPMSG1098_str(void);
-#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str), 12)
+#define BPMSG1098 bp_message_write_buffer(__builtin_tbladdress(BPMSG1098_str))
 void BPMSG1099_str(void);
-#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str), 6)
+#define BPMSG1099 bp_message_write_buffer(__builtin_tbladdress(BPMSG1099_str))
 void BPMSG1100_str(void);
-#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str), 2)
+#define BPMSG1100 bp_message_write_line(__builtin_tbladdress(BPMSG1100_str))
 void BPMSG1101_str(void);
-#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str), 7)
+#define BPMSG1101 bp_message_write_buffer(__builtin_tbladdress(BPMSG1101_str))
 void BPMSG1102_str(void);
-#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str), 6)
+#define BPMSG1102 bp_message_write_buffer(__builtin_tbladdress(BPMSG1102_str))
 void BPMSG1103_str(void);
-#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str), 8)
+#define BPMSG1103 bp_message_write_line(__builtin_tbladdress(BPMSG1103_str))
 void BPMSG1104_str(void);
-#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str), 8)
+#define BPMSG1104 bp_message_write_line(__builtin_tbladdress(BPMSG1104_str))
 void BPMSG1105_str(void);
-#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str), 14)
+#define BPMSG1105 bp_message_write_line(__builtin_tbladdress(BPMSG1105_str))
 void BPMSG1106_str(void);
-#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str), 14)
+#define BPMSG1106 bp_message_write_line(__builtin_tbladdress(BPMSG1106_str))
 void BPMSG1107_str(void);
-#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str), 16)
+#define BPMSG1107 bp_message_write_line(__builtin_tbladdress(BPMSG1107_str))
 void BPMSG1108_str(void);
-#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str), 13)
+#define BPMSG1108 bp_message_write_buffer(__builtin_tbladdress(BPMSG1108_str))
 void BPMSG1109_str(void);
-#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str), 10)
+#define BPMSG1109 bp_message_write_buffer(__builtin_tbladdress(BPMSG1109_str))
 void BPMSG1110_str(void);
-#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str), 21)
+#define BPMSG1110 bp_message_write_buffer(__builtin_tbladdress(BPMSG1110_str))
 void BPMSG1111_str(void);
-#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str), 23)
+#define BPMSG1111 bp_message_write_line(__builtin_tbladdress(BPMSG1111_str))
 void BPMSG1112_str(void);
-#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str), 14)
+#define BPMSG1112 bp_message_write_line(__builtin_tbladdress(BPMSG1112_str))
 void BPMSG1114_str(void);
-#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str), 21)
+#define BPMSG1114 bp_message_write_line(__builtin_tbladdress(BPMSG1114_str))
 void BPMSG1115_str(void);
-#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str), 7)
+#define BPMSG1115 bp_message_write_line(__builtin_tbladdress(BPMSG1115_str))
 void BPMSG1117_str(void);
-#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str), 6)
+#define BPMSG1117 bp_message_write_buffer(__builtin_tbladdress(BPMSG1117_str))
 void BPMSG1118_str(void);
-#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str), 30)
+#define BPMSG1118 bp_message_write_line(__builtin_tbladdress(BPMSG1118_str))
 void BPMSG1119_str(void);
-#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str), 12)
+#define BPMSG1119 bp_message_write_line(__builtin_tbladdress(BPMSG1119_str))
 void BPMSG1120_str(void);
-#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str), 34)
+#define BPMSG1120 bp_message_write_line(__builtin_tbladdress(BPMSG1120_str))
 void BPMSG1121_str(void);
-#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str), 30)
+#define BPMSG1121 bp_message_write_line(__builtin_tbladdress(BPMSG1121_str))
 void BPMSG1123_str(void);
-#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str), 27)
+#define BPMSG1123 bp_message_write_buffer(__builtin_tbladdress(BPMSG1123_str))
 void BPMSG1124_str(void);
-#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str), 28)
+#define BPMSG1124 bp_message_write_buffer(__builtin_tbladdress(BPMSG1124_str))
 void BPMSG1127_str(void);
-#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str), 34)
+#define BPMSG1127 bp_message_write_line(__builtin_tbladdress(BPMSG1127_str))
 void BPMSG1128_str(void);
-#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str), 18)
+#define BPMSG1128 bp_message_write_line(__builtin_tbladdress(BPMSG1128_str))
 void BPMSG1133_str(void);
-#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str), 190)
+#define BPMSG1133 bp_message_write_line(__builtin_tbladdress(BPMSG1133_str))
 void BPMSG1134_str(void);
-#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str), 20)
+#define BPMSG1134 bp_message_write_line(__builtin_tbladdress(BPMSG1134_str))
 void BPMSG1135_str(void);
-#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str), 14)
+#define BPMSG1135 bp_message_write_buffer(__builtin_tbladdress(BPMSG1135_str))
 void BPMSG1136_str(void);
-#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str), 5)
+#define BPMSG1136 bp_message_write_buffer(__builtin_tbladdress(BPMSG1136_str))
 void BPMSG1137_str(void);
-#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str), 6)
+#define BPMSG1137 bp_message_write_buffer(__builtin_tbladdress(BPMSG1137_str))
 void BPMSG1163_str(void);
-#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str), 46)
+#define BPMSG1163 bp_message_write_line(__builtin_tbladdress(BPMSG1163_str))
 void BPMSG1164_str(void);
-#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str), 4)
+#define BPMSG1164 bp_message_write_line(__builtin_tbladdress(BPMSG1164_str))
 void BPMSG1165_str(void);
-#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str), 3)
+#define BPMSG1165 bp_message_write_buffer(__builtin_tbladdress(BPMSG1165_str))
 void BPMSG1166_str(void);
-#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str), 8)
+#define BPMSG1166 bp_message_write_buffer(__builtin_tbladdress(BPMSG1166_str))
 void BPMSG1167_str(void);
-#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str), 8)
+#define BPMSG1167 bp_message_write_buffer(__builtin_tbladdress(BPMSG1167_str))
 void BPMSG1168_str(void);
-#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str), 8)
+#define BPMSG1168 bp_message_write_buffer(__builtin_tbladdress(BPMSG1168_str))
 void BPMSG1169_str(void);
-#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str), 4)
+#define BPMSG1169 bp_message_write_buffer(__builtin_tbladdress(BPMSG1169_str))
 void BPMSG1170_str(void);
-#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str), 14)
+#define BPMSG1170 bp_message_write_line(__builtin_tbladdress(BPMSG1170_str))
 void BPMSG1171_str(void);
-#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str), 2)
+#define BPMSG1171 bp_message_write_buffer(__builtin_tbladdress(BPMSG1171_str))
 void BPMSG1172_str(void);
-#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str), 3)
+#define BPMSG1172 bp_message_write_buffer(__builtin_tbladdress(BPMSG1172_str))
 void BPMSG1173_str(void);
-#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str), 4)
+#define BPMSG1173 bp_message_write_buffer(__builtin_tbladdress(BPMSG1173_str))
 void BPMSG1174_str(void);
-#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str), 3)
+#define BPMSG1174 bp_message_write_buffer(__builtin_tbladdress(BPMSG1174_str))
 void BPMSG1175_str(void);
-#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str), 8)
+#define BPMSG1175 bp_message_write_line(__builtin_tbladdress(BPMSG1175_str))
 void BPMSG1176_str(void);
-#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str), 10)
+#define BPMSG1176 bp_message_write_line(__builtin_tbladdress(BPMSG1176_str))
 void BPMSG1177_str(void);
-#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str), 10)
+#define BPMSG1177 bp_message_write_line(__builtin_tbladdress(BPMSG1177_str))
 void BPMSG1178_str(void);
-#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str), 38)
+#define BPMSG1178 bp_message_write_line(__builtin_tbladdress(BPMSG1178_str))
 void BPMSG1179_str(void);
-#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str), 6)
+#define BPMSG1179 bp_message_write_buffer(__builtin_tbladdress(BPMSG1179_str))
 void BPMSG1180_str(void);
-#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str), 8)
+#define BPMSG1180 bp_message_write_line(__builtin_tbladdress(BPMSG1180_str))
 void BPMSG1181_str(void);
-#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str), 4)
+#define BPMSG1181 bp_message_write_buffer(__builtin_tbladdress(BPMSG1181_str))
 void BPMSG1182_str(void);
-#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str), 3)
+#define BPMSG1182 bp_message_write_buffer(__builtin_tbladdress(BPMSG1182_str))
 void BPMSG1183_str(void);
-#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str), 4)
+#define BPMSG1183 bp_message_write_buffer(__builtin_tbladdress(BPMSG1183_str))
 void BPMSG1184_str(void);
-#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str), 2)
+#define BPMSG1184 bp_message_write_buffer(__builtin_tbladdress(BPMSG1184_str))
 void BPMSG1185_str(void);
-#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str), 3)
+#define BPMSG1185 bp_message_write_line(__builtin_tbladdress(BPMSG1185_str))
 void BPMSG1186_str(void);
-#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str), 5)
+#define BPMSG1186 bp_message_write_line(__builtin_tbladdress(BPMSG1186_str))
 void BPMSG1194_str(void);
-#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str), 3)
+#define BPMSG1194 bp_message_write_buffer(__builtin_tbladdress(BPMSG1194_str))
 void BPMSG1195_str(void);
-#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str), 3)
+#define BPMSG1195 bp_message_write_buffer(__builtin_tbladdress(BPMSG1195_str))
 void BPMSG1196_str(void);
-#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str), 15)
+#define BPMSG1196 bp_message_write_buffer(__builtin_tbladdress(BPMSG1196_str))
 void BPMSG1197_str(void);
-#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str), 15)
+#define BPMSG1197 bp_message_write_buffer(__builtin_tbladdress(BPMSG1197_str))
 void BPMSG1199_str(void);
-#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str), 84)
+#define BPMSG1199 bp_message_write_buffer(__builtin_tbladdress(BPMSG1199_str))
 void BPMSG1200_str(void);
-#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str), 33)
+#define BPMSG1200 bp_message_write_buffer(__builtin_tbladdress(BPMSG1200_str))
 void BPMSG1201_str(void);
-#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str), 50)
+#define BPMSG1201 bp_message_write_buffer(__builtin_tbladdress(BPMSG1201_str))
 void BPMSG1202_str(void);
-#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str), 32)
+#define BPMSG1202 bp_message_write_buffer(__builtin_tbladdress(BPMSG1202_str))
 void BPMSG1203_str(void);
-#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str), 124)
+#define BPMSG1203 bp_message_write_buffer(__builtin_tbladdress(BPMSG1203_str))
 void BPMSG1204_str(void);
-#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str), 11)
+#define BPMSG1204 bp_message_write_line(__builtin_tbladdress(BPMSG1204_str))
 void BPMSG1206_str(void);
-#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str), 14)
+#define BPMSG1206 bp_message_write_line(__builtin_tbladdress(BPMSG1206_str))
 void BPMSG1207_str(void);
-#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str), 28)
+#define BPMSG1207 bp_message_write_line(__builtin_tbladdress(BPMSG1207_str))
 void BPMSG1208_str(void);
-#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str), 20)
+#define BPMSG1208 bp_message_write_line(__builtin_tbladdress(BPMSG1208_str))
 void BPMSG1209_str(void);
-#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str), 34)
+#define BPMSG1209 bp_message_write_line(__builtin_tbladdress(BPMSG1209_str))
 void BPMSG1210_str(void);
-#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str), 7)
+#define BPMSG1210 bp_message_write_buffer(__builtin_tbladdress(BPMSG1210_str))
 void BPMSG1211_str(void);
-#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str), 27)
+#define BPMSG1211 bp_message_write_line(__builtin_tbladdress(BPMSG1211_str))
 void BPMSG1212_str(void);
-#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str), 2)
+#define BPMSG1212 bp_message_write_line(__builtin_tbladdress(BPMSG1212_str))
 void BPMSG1213_str(void);
-#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str), 20)
+#define BPMSG1213 bp_message_write_line(__builtin_tbladdress(BPMSG1213_str))
 void BPMSG1214_str(void);
-#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str), 18)
+#define BPMSG1214 bp_message_write_line(__builtin_tbladdress(BPMSG1214_str))
 void BPMSG1216_str(void);
-#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str), 29)
+#define BPMSG1216 bp_message_write_line(__builtin_tbladdress(BPMSG1216_str))
 void BPMSG1219_str(void);
-#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str), 152)
+#define BPMSG1219 bp_message_write_line(__builtin_tbladdress(BPMSG1219_str))
 void BPMSG1220_str(void);
-#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str), 36)
+#define BPMSG1220 bp_message_write_line(__builtin_tbladdress(BPMSG1220_str))
 void BPMSG1221_str(void);
-#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str), 4)
+#define BPMSG1221 bp_message_write_line(__builtin_tbladdress(BPMSG1221_str))
 void BPMSG1222_str(void);
-#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str), 5)
+#define BPMSG1222 bp_message_write_line(__builtin_tbladdress(BPMSG1222_str))
 void BPMSG1223_str(void);
-#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str), 10)
+#define BPMSG1223 bp_message_write_line(__builtin_tbladdress(BPMSG1223_str))
 void BPMSG1226_str(void);
-#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str), 10)
+#define BPMSG1226 bp_message_write_line(__builtin_tbladdress(BPMSG1226_str))
 void BPMSG1228_str(void);
-#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str), 10)
+#define BPMSG1228 bp_message_write_buffer(__builtin_tbladdress(BPMSG1228_str))
 void BPMSG1234_str(void);
-#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str), 4)
+#define BPMSG1234 bp_message_write_buffer(__builtin_tbladdress(BPMSG1234_str))
 void BPMSG1237_str(void);
-#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str), 8)
+#define BPMSG1237 bp_message_write_buffer(__builtin_tbladdress(BPMSG1237_str))
 void BPMSG1238_str(void);
-#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str), 38)
+#define BPMSG1238 bp_message_write_line(__builtin_tbladdress(BPMSG1238_str))
 void BPMSG1239_str(void);
-#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str), 28)
+#define BPMSG1239 bp_message_write_line(__builtin_tbladdress(BPMSG1239_str))
 void BPMSG1240_str(void);
-#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str), 16)
+#define BPMSG1240 bp_message_write_line(__builtin_tbladdress(BPMSG1240_str))
 void BPMSG1241_str(void);
-#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str), 14)
+#define BPMSG1241 bp_message_write_line(__builtin_tbladdress(BPMSG1241_str))
 void BPMSG1242_str(void);
-#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str), 15)
+#define BPMSG1242 bp_message_write_line(__builtin_tbladdress(BPMSG1242_str))
 void BPMSG1243_str(void);
-#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str), 5)
+#define BPMSG1243 bp_message_write_line(__builtin_tbladdress(BPMSG1243_str))
 void BPMSG1244_str(void);
-#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str), 14)
+#define BPMSG1244 bp_message_write_line(__builtin_tbladdress(BPMSG1244_str))
 void BPMSG1245_str(void);
-#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str), 11)
+#define BPMSG1245 bp_message_write_buffer(__builtin_tbladdress(BPMSG1245_str))
 void BPMSG1248_str(void);
-#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str), 25)
+#define BPMSG1248 bp_message_write_line(__builtin_tbladdress(BPMSG1248_str))
 void BPMSG1251_str(void);
-#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str), 17)
+#define BPMSG1251 bp_message_write_line(__builtin_tbladdress(BPMSG1251_str))
 void BPMSG1252_str(void);
-#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str), 27)
+#define BPMSG1252 bp_message_write_buffer(__builtin_tbladdress(BPMSG1252_str))
 void BPMSG1254_str(void);
-#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str), 19)
+#define BPMSG1254 bp_message_write_line(__builtin_tbladdress(BPMSG1254_str))
 void BPMSG1255_str(void);
-#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str), 12)
+#define BPMSG1255 bp_message_write_line(__builtin_tbladdress(BPMSG1255_str))
 void BPMSG1256_str(void);
-#define BPMSG1256 bp_message_write_line(__builtin_tbladdress(BPMSG1256_str), 86)
+#define BPMSG1256 bp_message_write_line(__builtin_tbladdress(BPMSG1256_str))
 void BPMSG1257_str(void);
-#define BPMSG1257 bp_message_write_buffer(__builtin_tbladdress(BPMSG1257_str), 36)
+#define BPMSG1257 bp_message_write_buffer(__builtin_tbladdress(BPMSG1257_str))
 void BPMSG1259_str(void);
-#define BPMSG1259 bp_message_write_line(__builtin_tbladdress(BPMSG1259_str), 9)
+#define BPMSG1259 bp_message_write_line(__builtin_tbladdress(BPMSG1259_str))
 void BPMSG1262_str(void);
-#define BPMSG1262 bp_message_write_line(__builtin_tbladdress(BPMSG1262_str), 11)
+#define BPMSG1262 bp_message_write_line(__builtin_tbladdress(BPMSG1262_str))
 void BPMSG1263_str(void);
-#define BPMSG1263 bp_message_write_line(__builtin_tbladdress(BPMSG1263_str), 23)
+#define BPMSG1263 bp_message_write_line(__builtin_tbladdress(BPMSG1263_str))
 void BPMSG1264_str(void);
-#define BPMSG1264 bp_message_write_line(__builtin_tbladdress(BPMSG1264_str), 23)
+#define BPMSG1264 bp_message_write_line(__builtin_tbladdress(BPMSG1264_str))
 void BPMSG1265_str(void);
-#define BPMSG1265 bp_message_write_line(__builtin_tbladdress(BPMSG1265_str), 6)
+#define BPMSG1265 bp_message_write_line(__builtin_tbladdress(BPMSG1265_str))
 void BPMSG1266_str(void);
-#define BPMSG1266 bp_message_write_buffer(__builtin_tbladdress(BPMSG1266_str), 3)
+#define BPMSG1266 bp_message_write_buffer(__builtin_tbladdress(BPMSG1266_str))
 void BPMSG1267_str(void);
-#define BPMSG1267 bp_message_write_buffer(__builtin_tbladdress(BPMSG1267_str), 3)
+#define BPMSG1267 bp_message_write_buffer(__builtin_tbladdress(BPMSG1267_str))
 void BPMSG1268_str(void);
-#define BPMSG1268 bp_message_write_buffer(__builtin_tbladdress(BPMSG1268_str), 2)
+#define BPMSG1268 bp_message_write_buffer(__builtin_tbladdress(BPMSG1268_str))
 void BPMSG1269_str(void);
-#define BPMSG1269 bp_message_write_buffer(__builtin_tbladdress(BPMSG1269_str), 10)
+#define BPMSG1269 bp_message_write_buffer(__builtin_tbladdress(BPMSG1269_str))
 void BPMSG1270_str(void);
-#define BPMSG1270 bp_message_write_buffer(__builtin_tbladdress(BPMSG1270_str), 4)
+#define BPMSG1270 bp_message_write_buffer(__builtin_tbladdress(BPMSG1270_str))
 void BPMSG1271_str(void);
-#define BPMSG1271 bp_message_write_line(__builtin_tbladdress(BPMSG1271_str), 87)
+#define BPMSG1271 bp_message_write_line(__builtin_tbladdress(BPMSG1271_str))
 void BPMSG1272_str(void);
-#define BPMSG1272 bp_message_write_buffer(__builtin_tbladdress(BPMSG1272_str), 25)
+#define BPMSG1272 bp_message_write_buffer(__builtin_tbladdress(BPMSG1272_str))
 void BPMSG1273_str(void);
-#define BPMSG1273 bp_message_write_line(__builtin_tbladdress(BPMSG1273_str), 7)
+#define BPMSG1273 bp_message_write_line(__builtin_tbladdress(BPMSG1273_str))
 void BPMSG1274_str(void);
-#define BPMSG1274 bp_message_write_line(__builtin_tbladdress(BPMSG1274_str), 8)
+#define BPMSG1274 bp_message_write_line(__builtin_tbladdress(BPMSG1274_str))
 void BPMSG1280_str(void);
-#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str), 19)
+#define BPMSG1280 bp_message_write_line(__builtin_tbladdress(BPMSG1280_str))
 void BPMSG1281_str(void);
-#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str), 14)
+#define BPMSG1281 bp_message_write_line(__builtin_tbladdress(BPMSG1281_str))
 void BPMSG1282_str(void);
-#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str), 56)
+#define BPMSG1282 bp_message_write_line(__builtin_tbladdress(BPMSG1282_str))
 void BPMSG1283_str(void);
-#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str), 15)
+#define BPMSG1283 bp_message_write_buffer(__builtin_tbladdress(BPMSG1283_str))
 void BPMSG1284_str(void);
-#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str), 15)
+#define BPMSG1284 bp_message_write_buffer(__builtin_tbladdress(BPMSG1284_str))
 void BPMSG1285_str(void);
-#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str), 4)
+#define BPMSG1285 bp_message_write_line(__builtin_tbladdress(BPMSG1285_str))
 void HLP1000_str(void);
-#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str), 32)
+#define HLP1000 bp_message_write_line(__builtin_tbladdress(HLP1000_str))
 void HLP1001_str(void);
-#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str), 75)
+#define HLP1001 bp_message_write_line(__builtin_tbladdress(HLP1001_str))
 void HLP1002_str(void);
-#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str), 37)
+#define HLP1002 bp_message_write_line(__builtin_tbladdress(HLP1002_str))
 void HLP1003_str(void);
-#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str), 39)
+#define HLP1003 bp_message_write_line(__builtin_tbladdress(HLP1003_str))
 void HLP1004_str(void);
-#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str), 20)
+#define HLP1004 bp_message_write_line(__builtin_tbladdress(HLP1004_str))
 void HLP1005_str(void);
-#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str), 26)
+#define HLP1005 bp_message_write_line(__builtin_tbladdress(HLP1005_str))
 void HLP1006_str(void);
-#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str), 39)
+#define HLP1006 bp_message_write_line(__builtin_tbladdress(HLP1006_str))
 void HLP1007_str(void);
-#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str), 26)
+#define HLP1007 bp_message_write_line(__builtin_tbladdress(HLP1007_str))
 void HLP1008_str(void);
-#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str), 45)
+#define HLP1008 bp_message_write_line(__builtin_tbladdress(HLP1008_str))
 void HLP1009_str(void);
-#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str), 39)
+#define HLP1009 bp_message_write_line(__builtin_tbladdress(HLP1009_str))
 void HLP1010_str(void);
-#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str), 57)
+#define HLP1010 bp_message_write_line(__builtin_tbladdress(HLP1010_str))
 void HLP1011_str(void);
-#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str), 52)
+#define HLP1011 bp_message_write_line(__builtin_tbladdress(HLP1011_str))
 void HLP1012_str(void);
-#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str), 27)
+#define HLP1012 bp_message_write_line(__builtin_tbladdress(HLP1012_str))
 void HLP1013_str(void);
-#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str), 32)
+#define HLP1013 bp_message_write_line(__builtin_tbladdress(HLP1013_str))
 void HLP1014_str(void);
-#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str), 27)
+#define HLP1014 bp_message_write_line(__builtin_tbladdress(HLP1014_str))
 void HLP1015_str(void);
-#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str), 36)
+#define HLP1015 bp_message_write_line(__builtin_tbladdress(HLP1015_str))
 void HLP1016_str(void);
-#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str), 32)
+#define HLP1016 bp_message_write_line(__builtin_tbladdress(HLP1016_str))
 void HLP1017_str(void);
-#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str), 24)
+#define HLP1017 bp_message_write_line(__builtin_tbladdress(HLP1017_str))
 void HLP1018_str(void);
-#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str), 31)
+#define HLP1018 bp_message_write_line(__builtin_tbladdress(HLP1018_str))
 void HLP1019_str(void);
-#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str), 40)
+#define HLP1019 bp_message_write_line(__builtin_tbladdress(HLP1019_str))
 void HLP1020_str(void);
-#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str), 36)
+#define HLP1020 bp_message_write_line(__builtin_tbladdress(HLP1020_str))
 void HLP1021_str(void);
-#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str), 53)
+#define HLP1021 bp_message_write_line(__builtin_tbladdress(HLP1021_str))
 void HLP1022_str(void);
-#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str), 61)
+#define HLP1022 bp_message_write_line(__builtin_tbladdress(HLP1022_str))
 void MSG_1WIRE_MODE_IDENTIFIER_str(void);
-#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str), 4)
+#define MSG_1WIRE_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_1WIRE_MODE_IDENTIFIER_str))
 void MSG_1WIRE_NEXT_CLOCK_ALERT_str(void);
-#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str), 36)
+#define MSG_1WIRE_NEXT_CLOCK_ALERT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_NEXT_CLOCK_ALERT_str))
 void MSG_1WIRE_SPEED_PROMPT_str(void);
-#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str), 62)
+#define MSG_1WIRE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_1WIRE_SPEED_PROMPT_str))
 void MSG_ACK_str(void);
-#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str), 3)
+#define MSG_ACK bp_message_write_buffer(__builtin_tbladdress(MSG_ACK_str))
 void MSG_ANY_KEY_TO_EXIT_PROMPT_str(void);
-#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str), 15)
+#define MSG_ANY_KEY_TO_EXIT_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_ANY_KEY_TO_EXIT_PROMPT_str))
 void MSG_BASE_CONVERTER_EQUAL_SIGN_str(void);
-#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str), 3)
+#define MSG_BASE_CONVERTER_EQUAL_SIGN bp_message_write_buffer(__builtin_tbladdress(MSG_BASE_CONVERTER_EQUAL_SIGN_str))
 void MSG_BAUD_DETECTION_SELECTED_str(void);
-#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(__builtin_tbladdress(MSG_BAUD_DETECTION_SELECTED_str), 25)
+#define MSG_BAUD_DETECTION_SELECTED bp_message_write_line(__builtin_tbladdress(MSG_BAUD_DETECTION_SELECTED_str))
 void MSG_BBIO_MODE_IDENTIFIER_str(void);
-#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str), 5)
+#define MSG_BBIO_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_BBIO_MODE_IDENTIFIER_str))
 void MSG_BINARY_NUMBER_PREFIX_str(void);
-#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str), 2)
+#define MSG_BINARY_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_BINARY_NUMBER_PREFIX_str))
 void MSG_CFG0_FIELD_str(void);
-#define MSG_CFG0_FIELD bp_message_write_buffer(__builtin_tbladdress(MSG_CFG0_FIELD_str), 6)
+#define MSG_CFG0_FIELD bp_message_write_buffer(__builtin_tbladdress(MSG_CFG0_FIELD_str))
 void MSG_CHIP_REVISION_A3_str(void);
-#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str), 2)
+#define MSG_CHIP_REVISION_A3 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A3_str))
 void MSG_CHIP_REVISION_A5_str(void);
-#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A5_str), 2)
+#define MSG_CHIP_REVISION_A5 bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_A5_str))
 void MSG_CHIP_REVISION_ID_BEGIN_str(void);
-#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str), 15)
+#define MSG_CHIP_REVISION_ID_BEGIN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_ID_BEGIN_str))
 void MSG_CHIP_REVISION_UNKNOWN_str(void);
-#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str), 3)
+#define MSG_CHIP_REVISION_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_CHIP_REVISION_UNKNOWN_str))
 void MSG_CLUTCH_DISENGAGED_str(void);
-#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str), 20)
+#define MSG_CLUTCH_DISENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_DISENGAGED_str))
 void MSG_CLUTCH_ENGAGED_str(void);
-#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str), 17)
+#define MSG_CLUTCH_ENGAGED bp_message_write_line(__builtin_tbladdress(MSG_CLUTCH_ENGAGED_str))
 void MSG_FINISH_SETUP_PROMPT_str(void);
-#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str), 61)
+#define MSG_FINISH_SETUP_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_FINISH_SETUP_PROMPT_str))
 void MSG_HEXADECIMAL_NUMBER_PREFIX_str(void);
-#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str), 2)
+#define MSG_HEXADECIMAL_NUMBER_PREFIX bp_message_write_buffer(__builtin_tbladdress(MSG_HEXADECIMAL_NUMBER_PREFIX_str))
 void MSG_I2C_MODE_IDENTIFIER_str(void);
-#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str), 4)
+#define MSG_I2C_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_MODE_IDENTIFIER_str))
 void MSG_I2C_PINS_STATE_str(void);
-#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str), 11)
+#define MSG_I2C_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_I2C_PINS_STATE_str))
 void MSG_I2C_READ_ADDRESS_END_str(void);
-#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str), 4)
+#define MSG_I2C_READ_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_READ_ADDRESS_END_str))
 void MSG_I2C_START_BIT_str(void);
-#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str), 13)
+#define MSG_I2C_START_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_START_BIT_str))
 void MSG_I2C_STOP_BIT_str(void);
-#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str), 12)
+#define MSG_I2C_STOP_BIT bp_message_write_line(__builtin_tbladdress(MSG_I2C_STOP_BIT_str))
 void MSG_I2C_WRITE_ADDRESS_END_str(void);
-#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str), 4)
+#define MSG_I2C_WRITE_ADDRESS_END bp_message_write_buffer(__builtin_tbladdress(MSG_I2C_WRITE_ADDRESS_END_str))
 void MSG_MODE_HEADER_END_str(void);
-#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str), 2)
+#define MSG_MODE_HEADER_END bp_message_write_line(__builtin_tbladdress(MSG_MODE_HEADER_END_str))
 void MSG_NACK_str(void);
-#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str), 4)
+#define MSG_NACK bp_message_write_buffer(__builtin_tbladdress(MSG_NACK_str))
 void MSG_NO_VOLTAGE_ON_PULLUP_PIN_str(void);
-#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str), 34)
+#define MSG_NO_VOLTAGE_ON_PULLUP_PIN bp_message_write_line(__builtin_tbladdress(MSG_NO_VOLTAGE_ON_PULLUP_PIN_str))
 void MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str(void);
-#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str), 38)
+#define MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str))
 void MSG_PIC_MODE_IDENTIFIER_str(void);
-#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str), 4)
+#define MSG_PIC_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_PIC_MODE_IDENTIFIER_str))
 void MSG_PIC_UNKNOWN_MODE_str(void);
-#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str), 12)
+#define MSG_PIC_UNKNOWN_MODE bp_message_write_line(__builtin_tbladdress(MSG_PIC_UNKNOWN_MODE_str))
 void MSG_PIN_OUTPUT_TYPE_PROMPT_str(void);
-#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str), 79)
+#define MSG_PIN_OUTPUT_TYPE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_PIN_OUTPUT_TYPE_PROMPT_str))
 void MSG_PWM_FREQUENCY_TOO_LOW_str(void);
-#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str), 36)
+#define MSG_PWM_FREQUENCY_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_PWM_FREQUENCY_TOO_LOW_str))
 void MSG_PWM_HZ_MARKER_str(void);
-#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str), 3)
+#define MSG_PWM_HZ_MARKER bp_message_write_line(__builtin_tbladdress(MSG_PWM_HZ_MARKER_str))
 void MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str), 12)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str))
 void MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str), 13)
+#define MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str))
 void MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str), 25)
+#define MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str), 10)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str), 6)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str))
 void MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str(void);
-#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str), 7)
+#define MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str), 11)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str), 6)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_TO_END bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str))
 void MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str(void);
-#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str), 15)
+#define MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str))
 void MSG_RAW2WIRE_ATR_REPLY_HEADER_str(void);
-#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str), 45)
+#define MSG_RAW2WIRE_ATR_REPLY_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_REPLY_HEADER_str))
 void MSG_RAW2WIRE_ATR_RFU_str(void);
-#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str), 3)
+#define MSG_RAW2WIRE_ATR_RFU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_ATR_RFU_str))
 void MSG_RAW2WIRE_ATR_TRIGGER_INFO_str(void);
-#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str), 63)
+#define MSG_RAW2WIRE_ATR_TRIGGER_INFO bp_message_write_line(__builtin_tbladdress(MSG_RAW2WIRE_ATR_TRIGGER_INFO_str))
 void MSG_RAW2WIRE_I2C_START_str(void);
-#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str), 8)
+#define MSG_RAW2WIRE_I2C_START bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_START_str))
 void MSG_RAW2WIRE_I2C_STOP_str(void);
-#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str), 6)
+#define MSG_RAW2WIRE_I2C_STOP bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_I2C_STOP_str))
 void MSG_RAW2WIRE_MACRO_MENU_str(void);
-#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str), 56)
+#define MSG_RAW2WIRE_MACRO_MENU bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MACRO_MENU_str))
 void MSG_RAW2WIRE_MODE_HEADER_str(void);
-#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str), 16)
+#define MSG_RAW2WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW2WIRE_MODE_HEADER_str))
 void MSG_RAW3WIRE_MODE_HEADER_str(void);
-#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str), 20)
+#define MSG_RAW3WIRE_MODE_HEADER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW3WIRE_MODE_HEADER_str))
 void MSG_RAW_BRG_VALUE_INPUT_str(void);
-#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str), 23)
+#define MSG_RAW_BRG_VALUE_INPUT bp_message_write_line(__builtin_tbladdress(MSG_RAW_BRG_VALUE_INPUT_str))
 void MSG_RAW_MODE_IDENTIFIER_str(void);
-#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str), 4)
+#define MSG_RAW_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_RAW_MODE_IDENTIFIER_str))
 void MSG_RESET_MESSAGE_str(void);
-#define MSG_RESET_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_RESET_MESSAGE_str), 5)
+#define MSG_RESET_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_RESET_MESSAGE_str))
 void MSG_SNIFFER_MESSAGE_str(void);
-#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str), 7)
+#define MSG_SNIFFER_MESSAGE bp_message_write_line(__builtin_tbladdress(MSG_SNIFFER_MESSAGE_str))
 void MSG_SOFTWARE_MODE_SPEED_PROMPT_str(void);
-#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str), 59)
+#define MSG_SOFTWARE_MODE_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SOFTWARE_MODE_SPEED_PROMPT_str))
 void MSG_SPI_COULD_NOT_KEEP_UP_str(void);
-#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str), 16)
+#define MSG_SPI_COULD_NOT_KEEP_UP bp_message_write_line(__builtin_tbladdress(MSG_SPI_COULD_NOT_KEEP_UP_str))
 void MSG_SPI_CS_DISABLED_str(void);
-#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str), 11)
+#define MSG_SPI_CS_DISABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_DISABLED_str))
 void MSG_SPI_CS_ENABLED_str(void);
-#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str), 10)
+#define MSG_SPI_CS_ENABLED bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_ENABLED_str))
 void MSG_SPI_CS_MODE_PROMPT_str(void);
-#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str), 29)
+#define MSG_SPI_CS_MODE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_CS_MODE_PROMPT_str))
 void MSG_SPI_EDGE_PROMPT_str(void);
-#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str), 67)
+#define MSG_SPI_EDGE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_EDGE_PROMPT_str))
 void MSG_SPI_MACRO_MENU_str(void);
-#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str), 206)
+#define MSG_SPI_MACRO_MENU bp_message_write_line(__builtin_tbladdress(MSG_SPI_MACRO_MENU_str))
 void MSG_SPI_MODE_HEADER_START_str(void);
-#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str), 32)
+#define MSG_SPI_MODE_HEADER_START bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_HEADER_START_str))
 void MSG_SPI_MODE_IDENTIFIER_str(void);
-#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str), 4)
+#define MSG_SPI_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_SPI_MODE_IDENTIFIER_str))
 void MSG_SPI_PINS_STATE_str(void);
-#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str), 16)
+#define MSG_SPI_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_SPI_PINS_STATE_str))
 void MSG_SPI_POLARITY_PROMPT_str(void);
-#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str), 53)
+#define MSG_SPI_POLARITY_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_POLARITY_PROMPT_str))
 void MSG_SPI_SAMPLE_PROMPT_str(void);
-#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str), 49)
+#define MSG_SPI_SAMPLE_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SAMPLE_PROMPT_str))
 void MSG_SPI_SPEED_PROMPT_str(void);
-#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str), 154)
+#define MSG_SPI_SPEED_PROMPT bp_message_write_line(__builtin_tbladdress(MSG_SPI_SPEED_PROMPT_str))
 void MSG_UART_MODE_IDENTIFIER_str(void);
-#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str), 4)
+#define MSG_UART_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_UART_MODE_IDENTIFIER_str))
 void MSG_UART_NORMAL_TO_EXIT_str(void);
-#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_NORMAL_TO_EXIT_str), 14)
+#define MSG_UART_NORMAL_TO_EXIT bp_message_write_line(__builtin_tbladdress(MSG_UART_NORMAL_TO_EXIT_str))
 void MSG_UART_PINS_STATE_str(void);
-#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str), 11)
+#define MSG_UART_PINS_STATE bp_message_write_line(__builtin_tbladdress(MSG_UART_PINS_STATE_str))
 void MSG_UNKNOWN_MACRO_ERROR_str(void);
-#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str), 36)
+#define MSG_UNKNOWN_MACRO_ERROR bp_message_write_line(__builtin_tbladdress(MSG_UNKNOWN_MACRO_ERROR_str))
 void MSG_USING_ONBOARD_I2C_EEPROM_str(void);
-#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(__builtin_tbladdress(MSG_USING_ONBOARD_I2C_EEPROM_str), 39)
+#define MSG_USING_ONBOARD_I2C_EEPROM bp_message_write_line(__builtin_tbladdress(MSG_USING_ONBOARD_I2C_EEPROM_str))
 void MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str(void);
-#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(__builtin_tbladdress(MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str), 41)
+#define MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT bp_message_write_line(__builtin_tbladdress(MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str))
 void MSG_VPU_3V3_MARKER_str(void);
-#define MSG_VPU_3V3_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_3V3_MARKER_str), 9)
+#define MSG_VPU_3V3_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_3V3_MARKER_str))
 void MSG_VPU_5V_MARKER_str(void);
-#define MSG_VPU_5V_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_5V_MARKER_str), 8)
+#define MSG_VPU_5V_MARKER bp_message_write_buffer(__builtin_tbladdress(MSG_VPU_5V_MARKER_str))
 void MSG_VREG_TOO_LOW_str(void);
-#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str), 31)
+#define MSG_VREG_TOO_LOW bp_message_write_line(__builtin_tbladdress(MSG_VREG_TOO_LOW_str))
 void MSG_XSV1_MODE_IDENTIFIER_str(void);
-#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_XSV1_MODE_IDENTIFIER_str), 4)
+#define MSG_XSV1_MODE_IDENTIFIER bp_message_write_buffer(__builtin_tbladdress(MSG_XSV1_MODE_IDENTIFIER_str))
 
 #endif /* BP_MESSAGES_V4_H */

--- a/Firmware/messages_v4.s
+++ b/Firmware/messages_v4.s
@@ -2,1793 +2,1793 @@
 	.section .text.BPMSG1004, code
 	.global _BPMSG1004_str
 _BPMSG1004_str:
-	.pascii "No device, try (ALARM) SEARCH macro first"
+	.pasciz "No device, try (ALARM) SEARCH macro first"
 
 	; BPMSG1005
 	.section .text.BPMSG1005, code
 	.global _BPMSG1005_str
 _BPMSG1005_str:
-	.pascii "ADDRESS MACRO "
+	.pasciz "ADDRESS MACRO "
 
 	; BPMSG1006
 	.section .text.BPMSG1006, code
 	.global _BPMSG1006_str
 _BPMSG1006_str:
-	.pascii " 0.Macro menu"
+	.pasciz " 0.Macro menu"
 
 	; BPMSG1007
 	.section .text.BPMSG1007, code
 	.global _BPMSG1007_str
 _BPMSG1007_str:
-	.pascii "Macro     1WIRE address"
+	.pasciz "Macro     1WIRE address"
 
 	; BPMSG1008
 	.section .text.BPMSG1008, code
 	.global _BPMSG1008_str
 _BPMSG1008_str:
-	.pascii "\r\n   *"
+	.pasciz "\r\n   *"
 
 	; BPMSG1009
 	.section .text.BPMSG1009, code
 	.global _BPMSG1009_str
 _BPMSG1009_str:
-	.pascii "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
+	.pasciz "1WIRE ROM COMMAND MACROs:\r\n 51.READ ROM (0x33) *for single device bus\r\n 85.MATCH ROM (0x55) *followed by 64bit address\r\n 204.SKIP ROM (0xCC) *followed by command\r\n 236.ALARM SEARCH (0xEC)\r\n 240.SEARCH ROM (0xF0)"
 
 	; BPMSG1010
 	.section .text.BPMSG1010, code
 	.global _BPMSG1010_str
 _BPMSG1010_str:
-	.pascii "ALARM SEARCH (0xEC)"
+	.pasciz "ALARM SEARCH (0xEC)"
 
 	; BPMSG1011
 	.section .text.BPMSG1011, code
 	.global _BPMSG1011_str
 _BPMSG1011_str:
-	.pascii "SEARCH (0xF0)"
+	.pasciz "SEARCH (0xF0)"
 
 	; BPMSG1012
 	.section .text.BPMSG1012, code
 	.global _BPMSG1012_str
 _BPMSG1012_str:
-	.pascii "Device IDs are available by MACRO, see (0)."
+	.pasciz "Device IDs are available by MACRO, see (0)."
 
 	; BPMSG1013
 	.section .text.BPMSG1013, code
 	.global _BPMSG1013_str
 _BPMSG1013_str:
-	.pascii "READ ROM (0x33): "
+	.pasciz "READ ROM (0x33): "
 
 	; BPMSG1014
 	.section .text.BPMSG1014, code
 	.global _BPMSG1014_str
 _BPMSG1014_str:
-	.pascii "MATCH ROM (0x55)"
+	.pasciz "MATCH ROM (0x55)"
 
 	; BPMSG1015
 	.section .text.BPMSG1015, code
 	.global _BPMSG1015_str
 _BPMSG1015_str:
-	.pascii "SKIP ROM (0xCC)"
+	.pasciz "SKIP ROM (0xCC)"
 
 	; BPMSG1017
 	.section .text.BPMSG1017, code
 	.global _BPMSG1017_str
 _BPMSG1017_str:
-	.pascii "BUS RESET "
+	.pasciz "BUS RESET "
 
 	; BPMSG1019
 	.section .text.BPMSG1019, code
 	.global _BPMSG1019_str
 _BPMSG1019_str:
-	.pascii "Warning: "
+	.pasciz "Warning: "
 
 	; BPMSG1020
 	.section .text.BPMSG1020, code
 	.global _BPMSG1020_str
 _BPMSG1020_str:
-	.pascii "*Short or no pull-up "
+	.pasciz "*Short or no pull-up "
 
 	; BPMSG1021
 	.section .text.BPMSG1021, code
 	.global _BPMSG1021_str
 _BPMSG1021_str:
-	.pascii "*No device detected "
+	.pasciz "*No device detected "
 
 	; BPMSG1022
 	.section .text.BPMSG1022, code
 	.global _BPMSG1022_str
 _BPMSG1022_str:
-	.pascii "DS18S20 High Pres Dig Therm"
+	.pasciz "DS18S20 High Pres Dig Therm"
 
 	; BPMSG1023
 	.section .text.BPMSG1023, code
 	.global _BPMSG1023_str
 _BPMSG1023_str:
-	.pascii "DS18B20 Prog Res Dig Therm"
+	.pasciz "DS18B20 Prog Res Dig Therm"
 
 	; BPMSG1024
 	.section .text.BPMSG1024, code
 	.global _BPMSG1024_str
 _BPMSG1024_str:
-	.pascii "DS1822 Econ Dig Therm"
+	.pasciz "DS1822 Econ Dig Therm"
 
 	; BPMSG1025
 	.section .text.BPMSG1025, code
 	.global _BPMSG1025_str
 _BPMSG1025_str:
-	.pascii "DS2404 Econram time Chip"
+	.pasciz "DS2404 Econram time Chip"
 
 	; BPMSG1026
 	.section .text.BPMSG1026, code
 	.global _BPMSG1026_str
 _BPMSG1026_str:
-	.pascii "DS2431 1K EEPROM"
+	.pasciz "DS2431 1K EEPROM"
 
 	; BPMSG1027
 	.section .text.BPMSG1027, code
 	.global _BPMSG1027_str
 _BPMSG1027_str:
-	.pascii "Unknown device"
+	.pasciz "Unknown device"
 
 	; BPMSG1028
 	.section .text.BPMSG1028, code
 	.global _BPMSG1028_str
 _BPMSG1028_str:
-	.pascii "PWM disabled"
+	.pasciz "PWM disabled"
 
 	; BPMSG1029
 	.section .text.BPMSG1029, code
 	.global _BPMSG1029_str
 _BPMSG1029_str:
-	.pascii "1KHz-4,000KHz PWM"
+	.pasciz "1KHz-4,000KHz PWM"
 
 	; BPMSG1030
 	.section .text.BPMSG1030, code
 	.global _BPMSG1030_str
 _BPMSG1030_str:
-	.pascii "Frequency in KHz "
+	.pasciz "Frequency in KHz "
 
 	; BPMSG1033
 	.section .text.BPMSG1033, code
 	.global _BPMSG1033_str
 _BPMSG1033_str:
-	.pascii "Duty cycle in % "
+	.pasciz "Duty cycle in % "
 
 	; BPMSG1034
 	.section .text.BPMSG1034, code
 	.global _BPMSG1034_str
 _BPMSG1034_str:
-	.pascii "PWM active"
+	.pasciz "PWM active"
 
 	; BPMSG1037
 	.section .text.BPMSG1037, code
 	.global _BPMSG1037_str
 _BPMSG1037_str:
-	.pascii "ERROR: PWM active, g to disable"
+	.pasciz "ERROR: PWM active, g to disable"
 
 	; BPMSG1038
 	.section .text.BPMSG1038, code
 	.global _BPMSG1038_str
 _BPMSG1038_str:
-	.pascii "AUX Frequency: "
+	.pasciz "AUX Frequency: "
 
 	; BPMSG1039
 	.section .text.BPMSG1039, code
 	.global _BPMSG1039_str
 _BPMSG1039_str:
-	.pascii "AUX INPUT/HI-Z"
+	.pasciz "AUX INPUT/HI-Z"
 
 	; BPMSG1040
 	.section .text.BPMSG1040, code
 	.global _BPMSG1040_str
 _BPMSG1040_str:
-	.pascii "AUX HIGH"
+	.pasciz "AUX HIGH"
 
 	; BPMSG1041
 	.section .text.BPMSG1041, code
 	.global _BPMSG1041_str
 _BPMSG1041_str:
-	.pascii "AUX LOW"
+	.pasciz "AUX LOW"
 
 	; BPMSG1042
 	.section .text.BPMSG1042, code
 	.global _BPMSG1042_str
 _BPMSG1042_str:
-	.pascii "VOLTMETER MODE"
+	.pasciz "VOLTMETER MODE"
 
 	; BPMSG1044
 	.section .text.BPMSG1044, code
 	.global _BPMSG1044_str
 _BPMSG1044_str:
-	.pascii "VOLTAGE PROBE: "
+	.pasciz "VOLTAGE PROBE: "
 
 	; BPMSG1045
 	.section .text.BPMSG1045, code
 	.global _BPMSG1045_str
 _BPMSG1045_str:
-	.pascii "V"
+	.pasciz "V"
 
 	; BPMSG1047
 	.section .text.BPMSG1047, code
 	.global _BPMSG1047_str
 _BPMSG1047_str:
-	.pascii "Error("
+	.pasciz "Error("
 
 	; BPMSG1048
 	.section .text.BPMSG1048, code
 	.global _BPMSG1048_str
 _BPMSG1048_str:
-	.pascii ") @line:"
+	.pasciz ") @line:"
 
 	; BPMSG1049
 	.section .text.BPMSG1049, code
 	.global _BPMSG1049_str
 _BPMSG1049_str:
-	.pascii " @pgmspace:"
+	.pasciz " @pgmspace:"
 
 	; BPMSG1050
 	.section .text.BPMSG1050, code
 	.global _BPMSG1050_str
 _BPMSG1050_str:
-	.pascii " bytes."
+	.pasciz " bytes."
 
 	; BPMSG1051
 	.section .text.BPMSG1051, code
 	.global _BPMSG1051_str
 _BPMSG1051_str:
-	.pascii "Too long!"
+	.pasciz "Too long!"
 
 	; BPMSG1052
 	.section .text.BPMSG1052, code
 	.global _BPMSG1052_str
 _BPMSG1052_str:
-	.pascii "Syntax error"
+	.pasciz "Syntax error"
 
 	; BPMSG1053
 	.section .text.BPMSG1053, code
 	.global _BPMSG1053_str
 _BPMSG1053_str:
-	.pascii "No EEPROM"
+	.pasciz "No EEPROM"
 
 	; BPMSG1054
 	.section .text.BPMSG1054, code
 	.global _BPMSG1054_str
 _BPMSG1054_str:
-	.pascii "Erasing"
+	.pasciz "Erasing"
 
 	; BPMSG1055
 	.section .text.BPMSG1055, code
 	.global _BPMSG1055_str
 _BPMSG1055_str:
-	.pascii "done"
+	.pasciz "done"
 
 	; BPMSG1056
 	.section .text.BPMSG1056, code
 	.global _BPMSG1056_str
 _BPMSG1056_str:
-	.pascii "Saving to slot "
+	.pasciz "Saving to slot "
 
 	; BPMSG1057
 	.section .text.BPMSG1057, code
 	.global _BPMSG1057_str
 _BPMSG1057_str:
-	.pascii "Invalid slot"
+	.pasciz "Invalid slot"
 
 	; BPMSG1058
 	.section .text.BPMSG1058, code
 	.global _BPMSG1058_str
 _BPMSG1058_str:
-	.pascii "Loading from slot "
+	.pasciz "Loading from slot "
 
 	; BPMSG1059
 	.section .text.BPMSG1059, code
 	.global _BPMSG1059_str
 _BPMSG1059_str:
-	.pascii "ERROR: command has no effect here"
+	.pasciz "ERROR: command has no effect here"
 
 	; BPMSG1064
 	.section .text.BPMSG1064, code
 	.global _BPMSG1064_str
 _BPMSG1064_str:
-	.pascii "I2C mode:\r\n 1. Software\r\n 2. Hardware"
+	.pasciz "I2C mode:\r\n 1. Software\r\n 2. Hardware"
 
 	; BPMSG1067
 	.section .text.BPMSG1067, code
 	.global _BPMSG1067_str
 _BPMSG1067_str:
-	.pascii "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
+	.pasciz "Set speed:\r\n 1. 100KHz\r\n 2. 400KHz\r\n 3. 1MHz"
 
 	; BPMSG1068
 	.section .text.BPMSG1068, code
 	.global _BPMSG1068_str
 _BPMSG1068_str:
-	.pascii "I2C (mod spd)=( "
+	.pasciz "I2C (mod spd)=( "
 
 	; BPMSG1069
 	.section .text.BPMSG1069, code
 	.global _BPMSG1069_str
 _BPMSG1069_str:
-	.pascii " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer\r\n 3.Connect to on-board EEPROM\r\n 4.Enable Writing the on-board EEPROM"
+	.pasciz " 0.Macro menu\r\n 1.7bit address search\r\n 2.I2C sniffer\r\n 3.Connect to on-board EEPROM\r\n 4.Enable Writing the on-board EEPROM"
 
 	; BPMSG1070
 	.section .text.BPMSG1070, code
 	.global _BPMSG1070_str
 _BPMSG1070_str:
-	.pascii "Searching I2C address space. Found devices at:"
+	.pasciz "Searching I2C address space. Found devices at:"
 
 	; BPMSG1072
 	.section .text.BPMSG1072, code
 	.global _BPMSG1072_str
 _BPMSG1072_str:
-	.pascii "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
+	.pasciz "Commandmode?\r\n1. 6b/14b\r\n2. 4b/16b"
 
 	; BPMSG1073
 	.section .text.BPMSG1073, code
 	.global _BPMSG1073_str
 _BPMSG1073_str:
-	.pascii "Delay?"
+	.pasciz "Delay?"
 
 	; BPMSG1074
 	.section .text.BPMSG1074, code
 	.global _BPMSG1074_str
 _BPMSG1074_str:
-	.pascii "PIC(mod dly)=("
+	.pasciz "PIC(mod dly)=("
 
 	; BPMSG1075
 	.section .text.BPMSG1075, code
 	.global _BPMSG1075_str
 _BPMSG1075_str:
-	.pascii "CMD"
+	.pasciz "CMD"
 
 	; BPMSG1076
 	.section .text.BPMSG1076, code
 	.global _BPMSG1076_str
 _BPMSG1076_str:
-	.pascii "DTA"
+	.pasciz "DTA"
 
 	; BPMSG1077
 	.section .text.BPMSG1077, code
 	.global _BPMSG1077_str
 _BPMSG1077_str:
-	.pascii "no read"
+	.pasciz "no read"
 
 	; BPMSG1078
 	.section .text.BPMSG1078, code
 	.global _BPMSG1078_str
 _BPMSG1078_str:
-	.pascii "unknown mode"
+	.pasciz "unknown mode"
 
 	; BPMSG1079
 	.section .text.BPMSG1079, code
 	.global _BPMSG1079_str
 _BPMSG1079_str:
-	.pascii "(1) get devID"
+	.pasciz "(1) get devID"
 
 	; BPMSG1080
 	.section .text.BPMSG1080, code
 	.global _BPMSG1080_str
 _BPMSG1080_str:
-	.pascii "DevID = "
+	.pasciz "DevID = "
 
 	; BPMSG1081
 	.section .text.BPMSG1081, code
 	.global _BPMSG1081_str
 _BPMSG1081_str:
-	.pascii " Rev = "
+	.pasciz " Rev = "
 
 	; BPMSG1082
 	.section .text.BPMSG1082, code
 	.global _BPMSG1082_str
 _BPMSG1082_str:
-	.pascii "Not implemented (yet)"
+	.pasciz "Not implemented (yet)"
 
 	; BPMSG1083
 	.section .text.BPMSG1083, code
 	.global _BPMSG1083_str
 _BPMSG1083_str:
-	.pascii "Please exit PIC programming mode"
+	.pasciz "Please exit PIC programming mode"
 
 	; BPMSG1084
 	.section .text.BPMSG1084, code
 	.global _BPMSG1084_str
 _BPMSG1084_str:
-	.pascii "(BASIC)"
+	.pasciz "(BASIC)"
 
 	; BPMSG1085
 	.section .text.BPMSG1085, code
 	.global _BPMSG1085_str
 _BPMSG1085_str:
-	.pascii "Ready"
+	.pasciz "Ready"
 
 	; BPMSG1086
 	.section .text.BPMSG1086, code
 	.global _BPMSG1086_str
 _BPMSG1086_str:
-	.pascii "a/A/@ controls AUX pin"
+	.pasciz "a/A/@ controls AUX pin"
 
 	; BPMSG1087
 	.section .text.BPMSG1087, code
 	.global _BPMSG1087_str
 _BPMSG1087_str:
-	.pascii "a/A/@ controls CS pin"
+	.pasciz "a/A/@ controls CS pin"
 
 	; BPMSG1088
 	.section .text.BPMSG1088, code
 	.global _BPMSG1088_str
 _BPMSG1088_str:
-	.pascii "Command not used in this mode"
+	.pasciz "Command not used in this mode"
 
 	; BPMSG1089
 	.section .text.BPMSG1089, code
 	.global _BPMSG1089_str
 _BPMSG1089_str:
-	.pascii "Pull-up resistors OFF"
+	.pasciz "Pull-up resistors OFF"
 
 	; BPMSG1091
 	.section .text.BPMSG1091, code
 	.global _BPMSG1091_str
 _BPMSG1091_str:
-	.pascii "Pull-up resistors ON"
+	.pasciz "Pull-up resistors ON"
 
 	; BPMSG1092
 	.section .text.BPMSG1092, code
 	.global _BPMSG1092_str
 _BPMSG1092_str:
-	.pascii "Self-test in HiZ mode only"
+	.pasciz "Self-test in HiZ mode only"
 
 	; BPMSG1093
 	.section .text.BPMSG1093, code
 	.global _BPMSG1093_str
 _BPMSG1093_str:
-	.pascii "RESET"
+	.pasciz "RESET"
 
 	; BPMSG1094
 	.section .text.BPMSG1094, code
 	.global _BPMSG1094_str
 _BPMSG1094_str:
-	.pascii "BOOTLOADER"
+	.pasciz "BOOTLOADER"
 
 	; BPMSG1095
 	.section .text.BPMSG1095, code
 	.global _BPMSG1095_str
 _BPMSG1095_str:
-	.pascii "AUX INPUT/HI-Z, READ: "
+	.pasciz "AUX INPUT/HI-Z, READ: "
 
 	; BPMSG1096
 	.section .text.BPMSG1096, code
 	.global _BPMSG1096_str
 _BPMSG1096_str:
-	.pascii "POWER SUPPLIES ON"
+	.pasciz "POWER SUPPLIES ON"
 
 	; BPMSG1097
 	.section .text.BPMSG1097, code
 	.global _BPMSG1097_str
 _BPMSG1097_str:
-	.pascii "POWER SUPPLIES OFF"
+	.pasciz "POWER SUPPLIES OFF"
 
 	; BPMSG1098
 	.section .text.BPMSG1098, code
 	.global _BPMSG1098_str
 _BPMSG1098_str:
-	.pascii "DATA STATE: "
+	.pasciz "DATA STATE: "
 
 	; BPMSG1099
 	.section .text.BPMSG1099, code
 	.global _BPMSG1099_str
 _BPMSG1099_str:
-	.pascii "DELAY "
+	.pasciz "DELAY "
 
 	; BPMSG1100
 	.section .text.BPMSG1100, code
 	.global _BPMSG1100_str
 _BPMSG1100_str:
-	.pascii "us"
+	.pasciz "us"
 
 	; BPMSG1101
 	.section .text.BPMSG1101, code
 	.global _BPMSG1101_str
 _BPMSG1101_str:
-	.pascii "WRITE: "
+	.pasciz "WRITE: "
 
 	; BPMSG1102
 	.section .text.BPMSG1102, code
 	.global _BPMSG1102_str
 _BPMSG1102_str:
-	.pascii "READ: "
+	.pasciz "READ: "
 
 	; BPMSG1103
 	.section .text.BPMSG1103, code
 	.global _BPMSG1103_str
 _BPMSG1103_str:
-	.pascii "CLOCK, 1"
+	.pasciz "CLOCK, 1"
 
 	; BPMSG1104
 	.section .text.BPMSG1104, code
 	.global _BPMSG1104_str
 _BPMSG1104_str:
-	.pascii "CLOCK, 0"
+	.pasciz "CLOCK, 0"
 
 	; BPMSG1105
 	.section .text.BPMSG1105, code
 	.global _BPMSG1105_str
 _BPMSG1105_str:
-	.pascii "DATA OUTPUT, 1"
+	.pasciz "DATA OUTPUT, 1"
 
 	; BPMSG1106
 	.section .text.BPMSG1106, code
 	.global _BPMSG1106_str
 _BPMSG1106_str:
-	.pascii "DATA OUTPUT, 0"
+	.pasciz "DATA OUTPUT, 0"
 
 	; BPMSG1107
 	.section .text.BPMSG1107, code
 	.global _BPMSG1107_str
 _BPMSG1107_str:
-	.pascii " *pin is now HiZ"
+	.pasciz " *pin is now HiZ"
 
 	; BPMSG1108
 	.section .text.BPMSG1108, code
 	.global _BPMSG1108_str
 _BPMSG1108_str:
-	.pascii "CLOCK TICKS: "
+	.pasciz "CLOCK TICKS: "
 
 	; BPMSG1109
 	.section .text.BPMSG1109, code
 	.global _BPMSG1109_str
 _BPMSG1109_str:
-	.pascii "READ BIT: "
+	.pasciz "READ BIT: "
 
 	; BPMSG1110
 	.section .text.BPMSG1110, code
 	.global _BPMSG1110_str
 _BPMSG1110_str:
-	.pascii "Syntax error at char "
+	.pasciz "Syntax error at char "
 
 	; BPMSG1111
 	.section .text.BPMSG1111, code
 	.global _BPMSG1111_str
 _BPMSG1111_str:
-	.pascii "x. exit(without change)"
+	.pasciz "x. exit(without change)"
 
 	; BPMSG1112
 	.section .text.BPMSG1112, code
 	.global _BPMSG1112_str
 _BPMSG1112_str:
-	.pascii "no mode change"
+	.pasciz "no mode change"
 
 	; BPMSG1114
 	.section .text.BPMSG1114, code
 	.global _BPMSG1114_str
 _BPMSG1114_str:
-	.pascii "Nonexistent protocol!"
+	.pasciz "Nonexistent protocol!"
 
 	; BPMSG1115
 	.section .text.BPMSG1115, code
 	.global _BPMSG1115_str
 _BPMSG1115_str:
-	.pascii "x. exit"
+	.pasciz "x. exit"
 
 	; BPMSG1117
 	.section .text.BPMSG1117, code
 	.global _BPMSG1117_str
 _BPMSG1117_str:
-	.pascii "DEVID:"
+	.pasciz "DEVID:"
 
 	; BPMSG1118
 	.section .text.BPMSG1118, code
 	.global _BPMSG1118_str
 _BPMSG1118_str:
-	.pascii "http://dangerousprototypes.com"
+	.pasciz "http://dangerousprototypes.com"
 
 	; BPMSG1119
 	.section .text.BPMSG1119, code
 	.global _BPMSG1119_str
 _BPMSG1119_str:
-	.pascii "*----------*"
+	.pasciz "*----------*"
 
 	; BPMSG1120
 	.section .text.BPMSG1120, code
 	.global _BPMSG1120_str
 _BPMSG1120_str:
-	.pascii "Open drain outputs (H=Hi-Z, L=GND)"
+	.pasciz "Open drain outputs (H=Hi-Z, L=GND)"
 
 	; BPMSG1121
 	.section .text.BPMSG1121, code
 	.global _BPMSG1121_str
 _BPMSG1121_str:
-	.pascii "Normal outputs (H=3.3v, L=GND)"
+	.pasciz "Normal outputs (H=3.3v, L=GND)"
 
 	; BPMSG1123
 	.section .text.BPMSG1123, code
 	.global _BPMSG1123_str
 _BPMSG1123_str:
-	.pascii "MSB set: MOST sig bit first"
+	.pasciz "MSB set: MOST sig bit first"
 
 	; BPMSG1124
 	.section .text.BPMSG1124, code
 	.global _BPMSG1124_str
 _BPMSG1124_str:
-	.pascii "LSB set: LEAST sig bit first"
+	.pasciz "LSB set: LEAST sig bit first"
 
 	; BPMSG1127
 	.section .text.BPMSG1127, code
 	.global _BPMSG1127_str
 _BPMSG1127_str:
-	.pascii " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
+	.pasciz " 1. HEX\r\n 2. DEC\r\n 3. BIN\r\n 4. RAW"
 
 	; BPMSG1128
 	.section .text.BPMSG1128, code
 	.global _BPMSG1128_str
 _BPMSG1128_str:
-	.pascii "Display format set"
+	.pasciz "Display format set"
 
 	; BPMSG1133
 	.section .text.BPMSG1133, code
 	.global _BPMSG1133_str
 _BPMSG1133_str:
-	.pascii "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. Input Custom BAUD\r\n11. Auto-Baud Detection (Activity Required)"
+	.pasciz "Set serial port speed: (bps)\r\n 1. 300\r\n 2. 1200\r\n 3. 2400\r\n 4. 4800\r\n 5. 9600\r\n 6. 19200\r\n 7. 38400\r\n 8. 57600\r\n 9. 115200\r\n10. Input Custom BAUD\r\n11. Auto-Baud Detection (Activity Required)"
 
 	; BPMSG1134
 	.section .text.BPMSG1134, code
 	.global _BPMSG1134_str
 _BPMSG1134_str:
-	.pascii "Adjust your terminal"
+	.pasciz "Adjust your terminal"
 
 	; BPMSG1135
 	.section .text.BPMSG1135, code
 	.global _BPMSG1135_str
 _BPMSG1135_str:
-	.pascii "Are you sure? "
+	.pasciz "Are you sure? "
 
 	; BPMSG1136
 	.section .text.BPMSG1136, code
 	.global _BPMSG1136_str
 _BPMSG1136_str:
-	.pascii "CFG1:"
+	.pasciz "CFG1:"
 
 	; BPMSG1137
 	.section .text.BPMSG1137, code
 	.global _BPMSG1137_str
 _BPMSG1137_str:
-	.pascii " CFG2:"
+	.pasciz " CFG2:"
 
 	; BPMSG1163
 	.section .text.BPMSG1163, code
 	.global _BPMSG1163_str
 _BPMSG1163_str:
-	.pascii "Disconnect any devices\r\nConnect (ADC to +3.3V)"
+	.pasciz "Disconnect any devices\r\nConnect (ADC to +3.3V)"
 
 	; BPMSG1164
 	.section .text.BPMSG1164, code
 	.global _BPMSG1164_str
 _BPMSG1164_str:
-	.pascii "Ctrl"
+	.pasciz "Ctrl"
 
 	; BPMSG1165
 	.section .text.BPMSG1165, code
 	.global _BPMSG1165_str
 _BPMSG1165_str:
-	.pascii "AUX"
+	.pasciz "AUX"
 
 	; BPMSG1166
 	.section .text.BPMSG1166, code
 	.global _BPMSG1166_str
 _BPMSG1166_str:
-	.pascii "MODE LED"
+	.pasciz "MODE LED"
 
 	; BPMSG1167
 	.section .text.BPMSG1167, code
 	.global _BPMSG1167_str
 _BPMSG1167_str:
-	.pascii "PULLUP H"
+	.pasciz "PULLUP H"
 
 	; BPMSG1168
 	.section .text.BPMSG1168, code
 	.global _BPMSG1168_str
 _BPMSG1168_str:
-	.pascii "PULLUP L"
+	.pasciz "PULLUP L"
 
 	; BPMSG1169
 	.section .text.BPMSG1169, code
 	.global _BPMSG1169_str
 _BPMSG1169_str:
-	.pascii "VREG"
+	.pasciz "VREG"
 
 	; BPMSG1170
 	.section .text.BPMSG1170, code
 	.global _BPMSG1170_str
 _BPMSG1170_str:
-	.pascii "ADC and supply"
+	.pasciz "ADC and supply"
 
 	; BPMSG1171
 	.section .text.BPMSG1171, code
 	.global _BPMSG1171_str
 _BPMSG1171_str:
-	.pascii "5V"
+	.pasciz "5V"
 
 	; BPMSG1172
 	.section .text.BPMSG1172, code
 	.global _BPMSG1172_str
 _BPMSG1172_str:
-	.pascii "VPU"
+	.pasciz "VPU"
 
 	; BPMSG1173
 	.section .text.BPMSG1173, code
 	.global _BPMSG1173_str
 _BPMSG1173_str:
-	.pascii "3.3V"
+	.pasciz "3.3V"
 
 	; BPMSG1174
 	.section .text.BPMSG1174, code
 	.global _BPMSG1174_str
 _BPMSG1174_str:
-	.pascii "ADC"
+	.pasciz "ADC"
 
 	; BPMSG1175
 	.section .text.BPMSG1175, code
 	.global _BPMSG1175_str
 _BPMSG1175_str:
-	.pascii "Bus high"
+	.pasciz "Bus high"
 
 	; BPMSG1176
 	.section .text.BPMSG1176, code
 	.global _BPMSG1176_str
 _BPMSG1176_str:
-	.pascii "Bus Hi-Z 0"
+	.pasciz "Bus Hi-Z 0"
 
 	; BPMSG1177
 	.section .text.BPMSG1177, code
 	.global _BPMSG1177_str
 _BPMSG1177_str:
-	.pascii "Bus Hi-Z 1"
+	.pasciz "Bus Hi-Z 1"
 
 	; BPMSG1178
 	.section .text.BPMSG1178, code
 	.global _BPMSG1178_str
 _BPMSG1178_str:
-	.pascii "MODE, VREG, and USB LEDs should be on!"
+	.pasciz "MODE, VREG, and USB LEDs should be on!"
 
 	; BPMSG1179
 	.section .text.BPMSG1179, code
 	.global _BPMSG1179_str
 _BPMSG1179_str:
-	.pascii "Found "
+	.pasciz "Found "
 
 	; BPMSG1180
 	.section .text.BPMSG1180, code
 	.global _BPMSG1180_str
 _BPMSG1180_str:
-	.pascii " errors."
+	.pasciz " errors."
 
 	; BPMSG1181
 	.section .text.BPMSG1181, code
 	.global _BPMSG1181_str
 _BPMSG1181_str:
-	.pascii "MOSI"
+	.pasciz "MOSI"
 
 	; BPMSG1182
 	.section .text.BPMSG1182, code
 	.global _BPMSG1182_str
 _BPMSG1182_str:
-	.pascii "CLK"
+	.pasciz "CLK"
 
 	; BPMSG1183
 	.section .text.BPMSG1183, code
 	.global _BPMSG1183_str
 _BPMSG1183_str:
-	.pascii "MISO"
+	.pasciz "MISO"
 
 	; BPMSG1184
 	.section .text.BPMSG1184, code
 	.global _BPMSG1184_str
 _BPMSG1184_str:
-	.pascii "CS"
+	.pasciz "CS"
 
 	; BPMSG1185
 	.section .text.BPMSG1185, code
 	.global _BPMSG1185_str
 _BPMSG1185_str:
-	.pascii " OK"
+	.pasciz " OK"
 
 	; BPMSG1186
 	.section .text.BPMSG1186, code
 	.global _BPMSG1186_str
 _BPMSG1186_str:
-	.pascii " FAIL"
+	.pasciz " FAIL"
 
 	; BPMSG1194
 	.section .text.BPMSG1194, code
 	.global _BPMSG1194_str
 _BPMSG1194_str:
-	.pascii "-p "
+	.pasciz "-p "
 
 	; BPMSG1195
 	.section .text.BPMSG1195, code
 	.global _BPMSG1195_str
 _BPMSG1195_str:
-	.pascii "-f "
+	.pasciz "-f "
 
 	; BPMSG1196
 	.section .text.BPMSG1196, code
 	.global _BPMSG1196_str
 _BPMSG1196_str:
-	.pascii "*Bytes dropped*"
+	.pasciz "*Bytes dropped*"
 
 	; BPMSG1197
 	.section .text.BPMSG1197, code
 	.global _BPMSG1197_str
 _BPMSG1197_str:
-	.pascii "FAILED, NO DATA"
+	.pasciz "FAILED, NO DATA"
 
 	; BPMSG1199
 	.section .text.BPMSG1199, code
 	.global _BPMSG1199_str
 _BPMSG1199_str:
-	.pascii "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
+	.pasciz "Data bits and parity:\r\n 1. 8, NONE *default \r\n 2. 8, EVEN \r\n 3. 8, ODD \r\n 4. 9, NONE"
 
 	; BPMSG1200
 	.section .text.BPMSG1200, code
 	.global _BPMSG1200_str
 _BPMSG1200_str:
-	.pascii "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
+	.pasciz "Stop bits:\r\n 1. 1 *default\r\n 2. 2"
 
 	; BPMSG1201
 	.section .text.BPMSG1201, code
 	.global _BPMSG1201_str
 _BPMSG1201_str:
-	.pascii "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
+	.pasciz "Receive polarity:\r\n 1. Idle 1 *default\r\n 2. Idle 0"
 
 	; BPMSG1202
 	.section .text.BPMSG1202, code
 	.global _BPMSG1202_str
 _BPMSG1202_str:
-	.pascii "UART (spd brg dbp sb rxp hiz)=( "
+	.pasciz "UART (spd brg dbp sb rxp hiz)=( "
 
 	; BPMSG1203
 	.section .text.BPMSG1203, code
 	.global _BPMSG1203_str
 _BPMSG1203_str:
-	.pascii " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection (Activity Needed)"
+	.pasciz " 0.Macro menu\r\n 1.Transparent bridge\r\n 2.Live monitor\r\n 3.Bridge with flow control\n\r 4.Auto Baud Detection (Activity Needed)"
 
 	; BPMSG1204
 	.section .text.BPMSG1204, code
 	.global _BPMSG1204_str
 _BPMSG1204_str:
-	.pascii "UART bridge"
+	.pasciz "UART bridge"
 
 	; BPMSG1206
 	.section .text.BPMSG1206, code
 	.global _BPMSG1206_str
 _BPMSG1206_str:
-	.pascii "Raw UART input"
+	.pasciz "Raw UART input"
 
 	; BPMSG1207
 	.section .text.BPMSG1207, code
 	.global _BPMSG1207_str
 _BPMSG1207_str:
-	.pascii "UART LIVE DISPLAY, } TO STOP"
+	.pasciz "UART LIVE DISPLAY, } TO STOP"
 
 	; BPMSG1208
 	.section .text.BPMSG1208, code
 	.global _BPMSG1208_str
 _BPMSG1208_str:
-	.pascii "LIVE DISPLAY STOPPED"
+	.pasciz "LIVE DISPLAY STOPPED"
 
 	; BPMSG1209
 	.section .text.BPMSG1209, code
 	.global _BPMSG1209_str
 _BPMSG1209_str:
-	.pascii "WARNING: pins not open drain (HiZ)"
+	.pasciz "WARNING: pins not open drain (HiZ)"
 
 	; BPMSG1210
 	.section .text.BPMSG1210, code
 	.global _BPMSG1210_str
 _BPMSG1210_str:
-	.pascii " REVID:"
+	.pasciz " REVID:"
 
 	; BPMSG1211
 	.section .text.BPMSG1211, code
 	.global _BPMSG1211_str
 _BPMSG1211_str:
-	.pascii "\r\nInvalid choice, try again"
+	.pasciz "\r\nInvalid choice, try again"
 
 	; BPMSG1212
 	.section .text.BPMSG1212, code
 	.global _BPMSG1212_str
 _BPMSG1212_str:
-	.pascii "ms"
+	.pasciz "ms"
 
 	; BPMSG1213
 	.section .text.BPMSG1213, code
 	.global _BPMSG1213_str
 _BPMSG1213_str:
-	.pascii "RS LOW, COMMAND MODE"
+	.pasciz "RS LOW, COMMAND MODE"
 
 	; BPMSG1214
 	.section .text.BPMSG1214, code
 	.global _BPMSG1214_str
 _BPMSG1214_str:
-	.pascii "RS HIGH, DATA MODE"
+	.pasciz "RS HIGH, DATA MODE"
 
 	; BPMSG1216
 	.section .text.BPMSG1216, code
 	.global _BPMSG1216_str
 _BPMSG1216_str:
-	.pascii "This mode requires an adapter"
+	.pasciz "This mode requires an adapter"
 
 	; BPMSG1219
 	.section .text.BPMSG1219, code
 	.global _BPMSG1219_str
 _BPMSG1219_str:
-	.pascii " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
+	.pasciz " 0.Macro menu\r\n 1.LCD Reset\r\n 2.Init LCD\r\n 3.Clear LCD\r\n 4.Cursor position ex:(4) 0\r\n 6.Write test numbers ex:(6) 80\r\n 7.Write test characters ex:(7) 80"
 
 	; BPMSG1220
 	.section .text.BPMSG1220, code
 	.global _BPMSG1220_str
 _BPMSG1220_str:
-	.pascii "Display lines:\r\n 1. 1 \r\n 2. Multiple"
+	.pasciz "Display lines:\r\n 1. 1 \r\n 2. Multiple"
 
 	; BPMSG1221
 	.section .text.BPMSG1221, code
 	.global _BPMSG1221_str
 _BPMSG1221_str:
-	.pascii "INIT"
+	.pasciz "INIT"
 
 	; BPMSG1222
 	.section .text.BPMSG1222, code
 	.global _BPMSG1222_str
 _BPMSG1222_str:
-	.pascii "CLEAR"
+	.pasciz "CLEAR"
 
 	; BPMSG1223
 	.section .text.BPMSG1223, code
 	.global _BPMSG1223_str
 _BPMSG1223_str:
-	.pascii "CURSOR SET"
+	.pasciz "CURSOR SET"
 
 	; BPMSG1226
 	.section .text.BPMSG1226, code
 	.global _BPMSG1226_str
 _BPMSG1226_str:
-	.pascii "Pinstates:"
+	.pasciz "Pinstates:"
 
 	; BPMSG1228
 	.section .text.BPMSG1228, code
 	.global _BPMSG1228_str
 _BPMSG1228_str:
-	.pascii "P\tP\tP\tI\tI\t"
+	.pasciz "P\tP\tP\tI\tI\t"
 
 	; BPMSG1234
 	.section .text.BPMSG1234, code
 	.global _BPMSG1234_str
 _BPMSG1234_str:
-	.pascii "GND\t"
+	.pasciz "GND\t"
 
 	; BPMSG1237
 	.section .text.BPMSG1237, code
 	.global _BPMSG1237_str
 _BPMSG1237_str:
-	.pascii " TIMEOUT"
+	.pasciz " TIMEOUT"
 
 	; BPMSG1238
 	.section .text.BPMSG1238, code
 	.global _BPMSG1238_str
 _BPMSG1238_str:
-	.pascii " 0. Macro menu\r\n 1. Live input monitor"
+	.pasciz " 0. Macro menu\r\n 1. Live input monitor"
 
 	; BPMSG1239
 	.section .text.BPMSG1239, code
 	.global _BPMSG1239_str
 _BPMSG1239_str:
-	.pascii "Input monitor, any key exits"
+	.pasciz "Input monitor, any key exits"
 
 	; BPMSG1240
 	.section .text.BPMSG1240, code
 	.global _BPMSG1240_str
 _BPMSG1240_str:
-	.pascii " *startbit error"
+	.pasciz " *startbit error"
 
 	; BPMSG1241
 	.section .text.BPMSG1241, code
 	.global _BPMSG1241_str
 _BPMSG1241_str:
-	.pascii " *parity error"
+	.pasciz " *parity error"
 
 	; BPMSG1242
 	.section .text.BPMSG1242, code
 	.global _BPMSG1242_str
 _BPMSG1242_str:
-	.pascii " *stopbit error"
+	.pasciz " *stopbit error"
 
 	; BPMSG1243
 	.section .text.BPMSG1243, code
 	.global _BPMSG1243_str
 _BPMSG1243_str:
-	.pascii " NONE"
+	.pasciz " NONE"
 
 	; BPMSG1244
 	.section .text.BPMSG1244, code
 	.global _BPMSG1244_str
 _BPMSG1244_str:
-	.pascii " UNKNOWN ERROR"
+	.pasciz " UNKNOWN ERROR"
 
 	; BPMSG1245
 	.section .text.BPMSG1245, code
 	.global _BPMSG1245_str
 _BPMSG1245_str:
-	.pascii " autorange "
+	.pasciz " autorange "
 
 	; BPMSG1248
 	.section .text.BPMSG1248, code
 	.global _BPMSG1248_str
 _BPMSG1248_str:
-	.pascii "Input a custom BAUD rate:"
+	.pasciz "Input a custom BAUD rate:"
 
 	; BPMSG1251
 	.section .text.BPMSG1251, code
 	.global _BPMSG1251_str
 _BPMSG1251_str:
-	.pascii "Space to continue"
+	.pasciz "Space to continue"
 
 	; BPMSG1252
 	.section .text.BPMSG1252, code
 	.global _BPMSG1252_str
 _BPMSG1252_str:
-	.pascii "Number of bits read/write: "
+	.pasciz "Number of bits read/write: "
 
 	; BPMSG1254
 	.section .text.BPMSG1254, code
 	.global _BPMSG1254_str
 _BPMSG1254_str:
-	.pascii "Position in degrees"
+	.pasciz "Position in degrees"
 
 	; BPMSG1255
 	.section .text.BPMSG1255, code
 	.global _BPMSG1255_str
 _BPMSG1255_str:
-	.pascii "Servo active"
+	.pasciz "Servo active"
 
 	; BPMSG1256
 	.section .text.BPMSG1256, code
 	.global _BPMSG1256_str
 _BPMSG1256_str:
-	.pascii "#12    \t#11    \t#10    \t#09   \t#08   \t#07   \t#06   \t#05   \t#04   \t#03   \t#02   \t#01   "
+	.pasciz "#12    \t#11    \t#10    \t#09   \t#08   \t#07   \t#06   \t#05   \t#04   \t#03   \t#02   \t#01   "
 
 	; BPMSG1257
 	.section .text.BPMSG1257, code
 	.global _BPMSG1257_str
 _BPMSG1257_str:
-	.pascii "GND\t5.0V\t3.3V\tVPU\tADC\tAUX2\tAUX1\tAUX\t"
+	.pasciz "GND\t5.0V\t3.3V\tVPU\tADC\tAUX2\tAUX1\tAUX\t"
 
 	; BPMSG1259
 	.section .text.BPMSG1259, code
 	.global _BPMSG1259_str
 _BPMSG1259_str:
-	.pascii "-\t-\t-\tOWD"
+	.pasciz "-\t-\t-\tOWD"
 
 	; BPMSG1262
 	.section .text.BPMSG1262, code
 	.global _BPMSG1262_str
 _BPMSG1262_str:
-	.pascii "-\t-\tPGC\tPGD"
+	.pasciz "-\t-\tPGC\tPGD"
 
 	; BPMSG1263
 	.section .text.BPMSG1263, code
 	.global _BPMSG1263_str
 _BPMSG1263_str:
-	.pascii "a/A/@ controls AUX1 pin"
+	.pasciz "a/A/@ controls AUX1 pin"
 
 	; BPMSG1264
 	.section .text.BPMSG1264, code
 	.global _BPMSG1264_str
 _BPMSG1264_str:
-	.pascii "a/A/@ controls AUX2 pin"
+	.pasciz "a/A/@ controls AUX2 pin"
 
 	; BPMSG1265
 	.section .text.BPMSG1265, code
 	.global _BPMSG1265_str
 _BPMSG1265_str:
-	.pascii "EEPROM"
+	.pasciz "EEPROM"
 
 	; BPMSG1266
 	.section .text.BPMSG1266, code
 	.global _BPMSG1266_str
 _BPMSG1266_str:
-	.pascii "SCL"
+	.pasciz "SCL"
 
 	; BPMSG1267
 	.section .text.BPMSG1267, code
 	.global _BPMSG1267_str
 _BPMSG1267_str:
-	.pascii "SDA"
+	.pasciz "SDA"
 
 	; BPMSG1268
 	.section .text.BPMSG1268, code
 	.global _BPMSG1268_str
 _BPMSG1268_str:
-	.pascii "WP"
+	.pasciz "WP"
 
 	; BPMSG1269
 	.section .text.BPMSG1269, code
 	.global _BPMSG1269_str
 _BPMSG1269_str:
-	.pascii "READ&WRITE"
+	.pasciz "READ&WRITE"
 
 	; BPMSG1270
 	.section .text.BPMSG1270, code
 	.global _BPMSG1270_str
 _BPMSG1270_str:
-	.pascii "Vusb"
+	.pasciz "Vusb"
 
 	; BPMSG1271
 	.section .text.BPMSG1271, code
 	.global _BPMSG1271_str
 _BPMSG1271_str:
-	.pascii "Select Vpu (Pullup) Source:\r\n 1) External (or None)\r\n 2) Onboard 3.3v\r\n 3) Onboard 5.0v"
+	.pasciz "Select Vpu (Pullup) Source:\r\n 1) External (or None)\r\n 2) Onboard 3.3v\r\n 3) Onboard 5.0v"
 
 	; BPMSG1272
 	.section .text.BPMSG1272, code
 	.global _BPMSG1272_str
 _BPMSG1272_str:
-	.pascii " on-board pullup voltage "
+	.pasciz " on-board pullup voltage "
 
 	; BPMSG1273
 	.section .text.BPMSG1273, code
 	.global _BPMSG1273_str
 _BPMSG1273_str:
-	.pascii "enabled"
+	.pasciz "enabled"
 
 	; BPMSG1274
 	.section .text.BPMSG1274, code
 	.global _BPMSG1274_str
 _BPMSG1274_str:
-	.pascii "disabled"
+	.pasciz "disabled"
 
 	; BPMSG1280
 	.section .text.BPMSG1280, code
 	.global _BPMSG1280_str
 _BPMSG1280_str:
-	.pascii "Waiting activity..."
+	.pasciz "Waiting activity..."
 
 	; BPMSG1281
 	.section .text.BPMSG1281, code
 	.global _BPMSG1281_str
 _BPMSG1281_str:
-	.pascii "** Early Exit!"
+	.pasciz "** Early Exit!"
 
 	; BPMSG1282
 	.section .text.BPMSG1282, code
 	.global _BPMSG1282_str
 _BPMSG1282_str:
-	.pascii "** Baud>16m: The BP cannot measure above 16000000, Done."
+	.pasciz "** Baud>16m: The BP cannot measure above 16000000, Done."
 
 	; BPMSG1283
 	.section .text.BPMSG1283, code
 	.global _BPMSG1283_str
 _BPMSG1283_str:
-	.pascii "\n\rCalculated: \t"
+	.pasciz "\n\rCalculated: \t"
 
 	; BPMSG1284
 	.section .text.BPMSG1284, code
 	.global _BPMSG1284_str
 _BPMSG1284_str:
-	.pascii "\n\rEstimated:  \t"
+	.pasciz "\n\rEstimated:  \t"
 
 	; BPMSG1285
 	.section .text.BPMSG1285, code
 	.global _BPMSG1285_str
 _BPMSG1285_str:
-	.pascii " bps"
+	.pasciz " bps"
 
 	; HLP1000
 	.section .text.HLP1000, code
 	.global _HLP1000_str
 _HLP1000_str:
-	.pascii "General\t\t\t\t\tProtocol interaction"
+	.pasciz "General\t\t\t\t\tProtocol interaction"
 
 	; HLP1001
 	.section .text.HLP1001, code
 	.global _HLP1001_str
 _HLP1001_str:
-	.pascii "---------------------------------------------------------------------------"
+	.pasciz "---------------------------------------------------------------------------"
 
 	; HLP1002
 	.section .text.HLP1002, code
 	.global _HLP1002_str
 _HLP1002_str:
-	.pascii "?\tThis help\t\t\t(0)\tList current macros"
+	.pasciz "?\tThis help\t\t\t(0)\tList current macros"
 
 	; HLP1003
 	.section .text.HLP1003, code
 	.global _HLP1003_str
 _HLP1003_str:
-	.pascii "=X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
+	.pasciz "=X/|X\tConverts X/reverse X\t\t(x)\tMacro x"
 
 	; HLP1004
 	.section .text.HLP1004, code
 	.global _HLP1004_str
 _HLP1004_str:
-	.pascii "~\tSelftest\t\t\t[\tStart"
+	.pasciz "~\tSelftest\t\t\t[\tStart"
 
 	; HLP1005
 	.section .text.HLP1005, code
 	.global _HLP1005_str
 _HLP1005_str:
-	.pascii "o\tSet output type\t\t\t]\tStop"
+	.pasciz "o\tSet output type\t\t\t]\tStop"
 
 	; HLP1006
 	.section .text.HLP1006, code
 	.global _HLP1006_str
 _HLP1006_str:
-	.pascii "$\tJump to bootloader\t\t{\tStart with read"
+	.pasciz "$\tJump to bootloader\t\t{\tStart with read"
 
 	; HLP1007
 	.section .text.HLP1007, code
 	.global _HLP1007_str
 _HLP1007_str:
-	.pascii "&/%\tDelay 1 us/ms\t\t\t}\tStop"
+	.pasciz "&/%\tDelay 1 us/ms\t\t\t}\tStop"
 
 	; HLP1008
 	.section .text.HLP1008, code
 	.global _HLP1008_str
 _HLP1008_str:
-	.pascii "a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
+	.pasciz "a/A/@\tAUXPIN (low/HI/READ)\t\t\"abc\"\tSend string"
 
 	; HLP1009
 	.section .text.HLP1009, code
 	.global _HLP1009_str
 _HLP1009_str:
-	.pascii "b\tSet baudrate\t\t\t123\tSend integer value"
+	.pasciz "b\tSet baudrate\t\t\t123\tSend integer value"
 
 	; HLP1010
 	.section .text.HLP1010, code
 	.global _HLP1010_str
 _HLP1010_str:
-	.pascii "c/C/k/K\tAUX assignment (A0/CS/A1/A2)\t0x123\tSend hex value"
+	.pasciz "c/C/k/K\tAUX assignment (A0/CS/A1/A2)\t0x123\tSend hex value"
 
 	; HLP1011
 	.section .text.HLP1011, code
 	.global _HLP1011_str
 _HLP1011_str:
-	.pascii "d/D\tMeasure ADC (once/CONT.)\t0b110\tSend binary value"
+	.pasciz "d/D\tMeasure ADC (once/CONT.)\t0b110\tSend binary value"
 
 	; HLP1012
 	.section .text.HLP1012, code
 	.global _HLP1012_str
 _HLP1012_str:
-	.pascii "f\tMeasure frequency\t\tr\tRead"
+	.pasciz "f\tMeasure frequency\t\tr\tRead"
 
 	; HLP1013
 	.section .text.HLP1013, code
 	.global _HLP1013_str
 _HLP1013_str:
-	.pascii "g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
+	.pasciz "g/S\tGenerate PWM/Servo\t\t/\tCLK hi"
 
 	; HLP1014
 	.section .text.HLP1014, code
 	.global _HLP1014_str
 _HLP1014_str:
-	.pascii "h\tCommandhistory\t\t\t\\\tCLK lo"
+	.pasciz "h\tCommandhistory\t\t\t\\\tCLK lo"
 
 	; HLP1015
 	.section .text.HLP1015, code
 	.global _HLP1015_str
 _HLP1015_str:
-	.pascii "i\tVersioninfo/statusinfo\t\t^\tCLK tick"
+	.pasciz "i\tVersioninfo/statusinfo\t\t^\tCLK tick"
 
 	; HLP1016
 	.section .text.HLP1016, code
 	.global _HLP1016_str
 _HLP1016_str:
-	.pascii "l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
+	.pasciz "l/L\tBitorder (msb/LSB)\t\t-\tDAT hi"
 
 	; HLP1017
 	.section .text.HLP1017, code
 	.global _HLP1017_str
 _HLP1017_str:
-	.pascii "m\tChange mode\t\t\t_\tDAT lo"
+	.pasciz "m\tChange mode\t\t\t_\tDAT lo"
 
 	; HLP1018
 	.section .text.HLP1018, code
 	.global _HLP1018_str
 _HLP1018_str:
-	.pascii "e\tSet Pullup Method\t\t.\tDAT read"
+	.pasciz "e\tSet Pullup Method\t\t.\tDAT read"
 
 	; HLP1019
 	.section .text.HLP1019, code
 	.global _HLP1019_str
 _HLP1019_str:
-	.pascii "p/P\tPullup resistors (off/ON)\t!\tBit read"
+	.pasciz "p/P\tPullup resistors (off/ON)\t!\tBit read"
 
 	; HLP1020
 	.section .text.HLP1020, code
 	.global _HLP1020_str
 _HLP1020_str:
-	.pascii "s\tScript engine\t\t\t:\tRepeat e.g. r:10"
+	.pasciz "s\tScript engine\t\t\t:\tRepeat e.g. r:10"
 
 	; HLP1021
 	.section .text.HLP1021, code
 	.global _HLP1021_str
 _HLP1021_str:
-	.pascii "v\tShow volts/states\t\t;\tBits to read/write e.g. 0x55;2"
+	.pasciz "v\tShow volts/states\t\t;\tBits to read/write e.g. 0x55;2"
 
 	; HLP1022
 	.section .text.HLP1022, code
 	.global _HLP1022_str
 _HLP1022_str:
-	.pascii "w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
+	.pasciz "w/W\tPSU (off/ON)\t\t<x>/<x= >/<0>\tUsermacro x/assign x/list all"
 
 	; MSG_1WIRE_MODE_IDENTIFIER
 	.section .text.MSG_1WIRE_MODE_IDENTIFIER, code
 	.global _MSG_1WIRE_MODE_IDENTIFIER_str
 _MSG_1WIRE_MODE_IDENTIFIER_str:
-	.pascii "1W01"
+	.pasciz "1W01"
 
 	; MSG_1WIRE_NEXT_CLOCK_ALERT
 	.section .text.MSG_1WIRE_NEXT_CLOCK_ALERT, code
 	.global _MSG_1WIRE_NEXT_CLOCK_ALERT_str
 _MSG_1WIRE_NEXT_CLOCK_ALERT_str:
-	.pascii " *next clock (^) will use this value"
+	.pasciz " *next clock (^) will use this value"
 
 	; MSG_1WIRE_SPEED_PROMPT
 	.section .text.MSG_1WIRE_SPEED_PROMPT, code
 	.global _MSG_1WIRE_SPEED_PROMPT_str
 _MSG_1WIRE_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
+	.pasciz "Set speed:\r\n 1. Standard (~16.3kbps) \r\n 2. Overdrive (~160kps)"
 
 	; MSG_ACK
 	.section .text.MSG_ACK, code
 	.global _MSG_ACK_str
 _MSG_ACK_str:
-	.pascii "ACK"
+	.pasciz "ACK"
 
 	; MSG_ANY_KEY_TO_EXIT_PROMPT
 	.section .text.MSG_ANY_KEY_TO_EXIT_PROMPT, code
 	.global _MSG_ANY_KEY_TO_EXIT_PROMPT_str
 _MSG_ANY_KEY_TO_EXIT_PROMPT_str:
-	.pascii "Any key to exit"
+	.pasciz "Any key to exit"
 
 	; MSG_BASE_CONVERTER_EQUAL_SIGN
 	.section .text.MSG_BASE_CONVERTER_EQUAL_SIGN, code
 	.global _MSG_BASE_CONVERTER_EQUAL_SIGN_str
 _MSG_BASE_CONVERTER_EQUAL_SIGN_str:
-	.pascii " = "
+	.pasciz " = "
 
 	; MSG_BAUD_DETECTION_SELECTED
 	.section .text.MSG_BAUD_DETECTION_SELECTED, code
 	.global _MSG_BAUD_DETECTION_SELECTED_str
 _MSG_BAUD_DETECTION_SELECTED_str:
-	.pascii "Baud detection selected.."
+	.pasciz "Baud detection selected.."
 
 	; MSG_BBIO_MODE_IDENTIFIER
 	.section .text.MSG_BBIO_MODE_IDENTIFIER, code
 	.global _MSG_BBIO_MODE_IDENTIFIER_str
 _MSG_BBIO_MODE_IDENTIFIER_str:
-	.pascii "BBIO1"
+	.pasciz "BBIO1"
 
 	; MSG_BINARY_NUMBER_PREFIX
 	.section .text.MSG_BINARY_NUMBER_PREFIX, code
 	.global _MSG_BINARY_NUMBER_PREFIX_str
 _MSG_BINARY_NUMBER_PREFIX_str:
-	.pascii "0b"
+	.pasciz "0b"
 
 	; MSG_CFG0_FIELD
 	.section .text.MSG_CFG0_FIELD, code
 	.global _MSG_CFG0_FIELD_str
 _MSG_CFG0_FIELD_str:
-	.pascii "CFG0: "
+	.pasciz "CFG0: "
 
 	; MSG_CHIP_REVISION_A3
 	.section .text.MSG_CHIP_REVISION_A3, code
 	.global _MSG_CHIP_REVISION_A3_str
 _MSG_CHIP_REVISION_A3_str:
-	.pascii "A3"
+	.pasciz "A3"
 
 	; MSG_CHIP_REVISION_A5
 	.section .text.MSG_CHIP_REVISION_A5, code
 	.global _MSG_CHIP_REVISION_A5_str
 _MSG_CHIP_REVISION_A5_str:
-	.pascii "A5"
+	.pasciz "A5"
 
 	; MSG_CHIP_REVISION_ID_BEGIN
 	.section .text.MSG_CHIP_REVISION_ID_BEGIN, code
 	.global _MSG_CHIP_REVISION_ID_BEGIN_str
 _MSG_CHIP_REVISION_ID_BEGIN_str:
-	.pascii " (24FJ256GB106 "
+	.pasciz " (24FJ256GB106 "
 
 	; MSG_CHIP_REVISION_UNKNOWN
 	.section .text.MSG_CHIP_REVISION_UNKNOWN, code
 	.global _MSG_CHIP_REVISION_UNKNOWN_str
 _MSG_CHIP_REVISION_UNKNOWN_str:
-	.pascii "UNK"
+	.pasciz "UNK"
 
 	; MSG_CLUTCH_DISENGAGED
 	.section .text.MSG_CLUTCH_DISENGAGED, code
 	.global _MSG_CLUTCH_DISENGAGED_str
 _MSG_CLUTCH_DISENGAGED_str:
-	.pascii "Clutch disengaged!!!"
+	.pasciz "Clutch disengaged!!!"
 
 	; MSG_CLUTCH_ENGAGED
 	.section .text.MSG_CLUTCH_ENGAGED, code
 	.global _MSG_CLUTCH_ENGAGED_str
 _MSG_CLUTCH_ENGAGED_str:
-	.pascii "Clutch engaged!!!"
+	.pasciz "Clutch engaged!!!"
 
 	; MSG_FINISH_SETUP_PROMPT
 	.section .text.MSG_FINISH_SETUP_PROMPT, code
 	.global _MSG_FINISH_SETUP_PROMPT_str
 _MSG_FINISH_SETUP_PROMPT_str:
-	.pascii "To finish setup, start up the power supplies with command 'W'"
+	.pasciz "To finish setup, start up the power supplies with command 'W'"
 
 	; MSG_HEXADECIMAL_NUMBER_PREFIX
 	.section .text.MSG_HEXADECIMAL_NUMBER_PREFIX, code
 	.global _MSG_HEXADECIMAL_NUMBER_PREFIX_str
 _MSG_HEXADECIMAL_NUMBER_PREFIX_str:
-	.pascii "0x"
+	.pasciz "0x"
 
 	; MSG_I2C_MODE_IDENTIFIER
 	.section .text.MSG_I2C_MODE_IDENTIFIER, code
 	.global _MSG_I2C_MODE_IDENTIFIER_str
 _MSG_I2C_MODE_IDENTIFIER_str:
-	.pascii "I2C1"
+	.pasciz "I2C1"
 
 	; MSG_I2C_PINS_STATE
 	.section .text.MSG_I2C_PINS_STATE, code
 	.global _MSG_I2C_PINS_STATE_str
 _MSG_I2C_PINS_STATE_str:
-	.pascii "-\t-\tSCL\tSDA"
+	.pasciz "-\t-\tSCL\tSDA"
 
 	; MSG_I2C_READ_ADDRESS_END
 	.section .text.MSG_I2C_READ_ADDRESS_END, code
 	.global _MSG_I2C_READ_ADDRESS_END_str
 _MSG_I2C_READ_ADDRESS_END_str:
-	.pascii " R) "
+	.pasciz " R) "
 
 	; MSG_I2C_START_BIT
 	.section .text.MSG_I2C_START_BIT, code
 	.global _MSG_I2C_START_BIT_str
 _MSG_I2C_START_BIT_str:
-	.pascii "I2C START BIT"
+	.pasciz "I2C START BIT"
 
 	; MSG_I2C_STOP_BIT
 	.section .text.MSG_I2C_STOP_BIT, code
 	.global _MSG_I2C_STOP_BIT_str
 _MSG_I2C_STOP_BIT_str:
-	.pascii "I2C STOP BIT"
+	.pasciz "I2C STOP BIT"
 
 	; MSG_I2C_WRITE_ADDRESS_END
 	.section .text.MSG_I2C_WRITE_ADDRESS_END, code
 	.global _MSG_I2C_WRITE_ADDRESS_END_str
 _MSG_I2C_WRITE_ADDRESS_END_str:
-	.pascii " W) "
+	.pasciz " W) "
 
 	; MSG_MODE_HEADER_END
 	.section .text.MSG_MODE_HEADER_END, code
 	.global _MSG_MODE_HEADER_END_str
 _MSG_MODE_HEADER_END_str:
-	.pascii " )"
+	.pasciz " )"
 
 	; MSG_NACK
 	.section .text.MSG_NACK, code
 	.global _MSG_NACK_str
 _MSG_NACK_str:
-	.pascii "NACK"
+	.pasciz "NACK"
 
 	; MSG_NO_VOLTAGE_ON_PULLUP_PIN
 	.section .text.MSG_NO_VOLTAGE_ON_PULLUP_PIN, code
 	.global _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str
 _MSG_NO_VOLTAGE_ON_PULLUP_PIN_str:
-	.pascii "Warning: no voltage on Vpullup pin"
+	.pasciz "Warning: no voltage on Vpullup pin"
 
 	; MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED
 	.section .text.MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED, code
 	.global _MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str
 _MSG_ONBOARD_I2C_EEPROM_WRITE_PROTECT_DISABLED_str:
-	.pascii "On-board EEPROM write protect disabled"
+	.pasciz "On-board EEPROM write protect disabled"
 
 	; MSG_PIC_MODE_IDENTIFIER
 	.section .text.MSG_PIC_MODE_IDENTIFIER, code
 	.global _MSG_PIC_MODE_IDENTIFIER_str
 _MSG_PIC_MODE_IDENTIFIER_str:
-	.pascii "PIC1"
+	.pasciz "PIC1"
 
 	; MSG_PIC_UNKNOWN_MODE
 	.section .text.MSG_PIC_UNKNOWN_MODE, code
 	.global _MSG_PIC_UNKNOWN_MODE_str
 _MSG_PIC_UNKNOWN_MODE_str:
-	.pascii "unknown mode"
+	.pasciz "unknown mode"
 
 	; MSG_PIN_OUTPUT_TYPE_PROMPT
 	.section .text.MSG_PIN_OUTPUT_TYPE_PROMPT, code
 	.global _MSG_PIN_OUTPUT_TYPE_PROMPT_str
 _MSG_PIN_OUTPUT_TYPE_PROMPT_str:
-	.pascii "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
+	.pasciz "Select output type:\r\n 1. Open drain (H=Hi-Z, L=GND)\r\n 2. Normal (H=3.3V, L=GND)"
 
 	; MSG_PWM_FREQUENCY_TOO_LOW
 	.section .text.MSG_PWM_FREQUENCY_TOO_LOW, code
 	.global _MSG_PWM_FREQUENCY_TOO_LOW_str
 _MSG_PWM_FREQUENCY_TOO_LOW_str:
-	.pascii "Frequencies < 1Hz are not supported."
+	.pasciz "Frequencies < 1Hz are not supported."
 
 	; MSG_PWM_HZ_MARKER
 	.section .text.MSG_PWM_HZ_MARKER, code
 	.global _MSG_PWM_HZ_MARKER_str
 _MSG_PWM_HZ_MARKER_str:
-	.pascii " Hz"
+	.pasciz " Hz"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str
 _MSG_RAW2WIRE_ATR_DATA_UNITS_HEADER_str:
-	.pascii "Data units: "
+	.pasciz "Data units: "
 
 	; MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str
 _MSG_RAW2WIRE_ATR_DATA_UNITS_NO_INDICATION_str:
-	.pascii "no indication"
+	.pasciz "no indication"
 
 	; MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH
 	.section .text.MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH, code
 	.global _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str
 _MSG_RAW2WIRE_ATR_DATA_UNIT_LENGTH_str:
-	.pascii "Data unit length (bits): "
+	.pasciz "Data unit length (bits): "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_2WIRE_str:
-	.pascii "2 wire"
+	.pasciz "2 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_3WIRE_str:
-	.pascii "3 wire"
+	.pasciz "3 wire"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_HEADER_str:
-	.pascii "Protocol: "
+	.pasciz "Protocol: "
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_SERIAL_str:
-	.pascii "serial"
+	.pasciz "serial"
 
 	; MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN
 	.section .text.MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN, code
 	.global _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str
 _MSG_RAW2WIRE_ATR_PROTOCOL_UNKNOWN_str:
-	.pascii "unknown"
+	.pasciz "unknown"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_HEADER_str:
-	.pascii "Read type: "
+	.pasciz "Read type: "
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_TO_END
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_TO_END, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_TO_END_str:
-	.pascii "to end"
+	.pasciz "to end"
 
 	; MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH
 	.section .text.MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH, code
 	.global _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str
 _MSG_RAW2WIRE_ATR_READ_TYPE_VARIABLE_LENGTH_str:
-	.pascii "variable length"
+	.pasciz "variable length"
 
 	; MSG_RAW2WIRE_ATR_REPLY_HEADER
 	.section .text.MSG_RAW2WIRE_ATR_REPLY_HEADER, code
 	.global _MSG_RAW2WIRE_ATR_REPLY_HEADER_str
 _MSG_RAW2WIRE_ATR_REPLY_HEADER_str:
-	.pascii "ISO 7816-3 reply (uses current LSB setting): "
+	.pasciz "ISO 7816-3 reply (uses current LSB setting): "
 
 	; MSG_RAW2WIRE_ATR_RFU
 	.section .text.MSG_RAW2WIRE_ATR_RFU, code
 	.global _MSG_RAW2WIRE_ATR_RFU_str
 _MSG_RAW2WIRE_ATR_RFU_str:
-	.pascii "RFU"
+	.pasciz "RFU"
 
 	; MSG_RAW2WIRE_ATR_TRIGGER_INFO
 	.section .text.MSG_RAW2WIRE_ATR_TRIGGER_INFO, code
 	.global _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str
 _MSG_RAW2WIRE_ATR_TRIGGER_INFO_str:
-	.pascii "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
+	.pasciz "ISO 7816-3 ATR (RESET on CS)\r\nRESET HIGH, CLOCK TICK, RESET LOW"
 
 	; MSG_RAW2WIRE_I2C_START
 	.section .text.MSG_RAW2WIRE_I2C_START, code
 	.global _MSG_RAW2WIRE_I2C_START_str
 _MSG_RAW2WIRE_I2C_START_str:
-	.pascii "(\\-/_\\-)"
+	.pasciz "(\\-/_\\-)"
 
 	; MSG_RAW2WIRE_I2C_STOP
 	.section .text.MSG_RAW2WIRE_I2C_STOP, code
 	.global _MSG_RAW2WIRE_I2C_STOP_str
 _MSG_RAW2WIRE_I2C_STOP_str:
-	.pascii "(\\_/-)"
+	.pasciz "(\\_/-)"
 
 	; MSG_RAW2WIRE_MACRO_MENU
 	.section .text.MSG_RAW2WIRE_MACRO_MENU, code
 	.global _MSG_RAW2WIRE_MACRO_MENU_str
 _MSG_RAW2WIRE_MACRO_MENU_str:
-	.pascii " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
+	.pasciz " 0.Macro menu\r\n 1.ISO7816-3 ATR\r\n 2.ISO7816-3 parse only"
 
 	; MSG_RAW2WIRE_MODE_HEADER
 	.section .text.MSG_RAW2WIRE_MODE_HEADER, code
 	.global _MSG_RAW2WIRE_MODE_HEADER_str
 _MSG_RAW2WIRE_MODE_HEADER_str:
-	.pascii "R2W (spd hiz)=( "
+	.pasciz "R2W (spd hiz)=( "
 
 	; MSG_RAW3WIRE_MODE_HEADER
 	.section .text.MSG_RAW3WIRE_MODE_HEADER, code
 	.global _MSG_RAW3WIRE_MODE_HEADER_str
 _MSG_RAW3WIRE_MODE_HEADER_str:
-	.pascii "R3W (spd csl hiz)=( "
+	.pasciz "R3W (spd csl hiz)=( "
 
 	; MSG_RAW_BRG_VALUE_INPUT
 	.section .text.MSG_RAW_BRG_VALUE_INPUT, code
 	.global _MSG_RAW_BRG_VALUE_INPUT_str
 _MSG_RAW_BRG_VALUE_INPUT_str:
-	.pascii "Enter raw value for BRG"
+	.pasciz "Enter raw value for BRG"
 
 	; MSG_RAW_MODE_IDENTIFIER
 	.section .text.MSG_RAW_MODE_IDENTIFIER, code
 	.global _MSG_RAW_MODE_IDENTIFIER_str
 _MSG_RAW_MODE_IDENTIFIER_str:
-	.pascii "RAW1"
+	.pasciz "RAW1"
 
 	; MSG_RESET_MESSAGE
 	.section .text.MSG_RESET_MESSAGE, code
 	.global _MSG_RESET_MESSAGE_str
 _MSG_RESET_MESSAGE_str:
-	.pascii "RESET"
+	.pasciz "RESET"
 
 	; MSG_SNIFFER_MESSAGE
 	.section .text.MSG_SNIFFER_MESSAGE, code
 	.global _MSG_SNIFFER_MESSAGE_str
 _MSG_SNIFFER_MESSAGE_str:
-	.pascii "Sniffer"
+	.pasciz "Sniffer"
 
 	; MSG_SOFTWARE_MODE_SPEED_PROMPT
 	.section .text.MSG_SOFTWARE_MODE_SPEED_PROMPT, code
 	.global _MSG_SOFTWARE_MODE_SPEED_PROMPT_str
 _MSG_SOFTWARE_MODE_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
+	.pasciz "Set speed:\r\n 1. ~5KHz\r\n 2. ~50KHz\r\n 3. ~100KHz\r\n 4. ~400KHz"
 
 	; MSG_SPI_COULD_NOT_KEEP_UP
 	.section .text.MSG_SPI_COULD_NOT_KEEP_UP, code
 	.global _MSG_SPI_COULD_NOT_KEEP_UP_str
 _MSG_SPI_COULD_NOT_KEEP_UP_str:
-	.pascii "Couldn't keep up"
+	.pasciz "Couldn't keep up"
 
 	; MSG_SPI_CS_DISABLED
 	.section .text.MSG_SPI_CS_DISABLED, code
 	.global _MSG_SPI_CS_DISABLED_str
 _MSG_SPI_CS_DISABLED_str:
-	.pascii "CS DISABLED"
+	.pasciz "CS DISABLED"
 
 	; MSG_SPI_CS_ENABLED
 	.section .text.MSG_SPI_CS_ENABLED, code
 	.global _MSG_SPI_CS_ENABLED_str
 _MSG_SPI_CS_ENABLED_str:
-	.pascii "CS ENABLED"
+	.pasciz "CS ENABLED"
 
 	; MSG_SPI_CS_MODE_PROMPT
 	.section .text.MSG_SPI_CS_MODE_PROMPT, code
 	.global _MSG_SPI_CS_MODE_PROMPT_str
 _MSG_SPI_CS_MODE_PROMPT_str:
-	.pascii "CS:\r\n 1. CS\r\n 2. /CS *default"
+	.pasciz "CS:\r\n 1. CS\r\n 2. /CS *default"
 
 	; MSG_SPI_EDGE_PROMPT
 	.section .text.MSG_SPI_EDGE_PROMPT, code
 	.global _MSG_SPI_EDGE_PROMPT_str
 _MSG_SPI_EDGE_PROMPT_str:
-	.pascii "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
+	.pasciz "Output clock edge:\r\n 1. Idle to active\r\n 2. Active to idle *default"
 
 	; MSG_SPI_MACRO_MENU
 	.section .text.MSG_SPI_MACRO_MENU, code
 	.global _MSG_SPI_MACRO_MENU_str
 _MSG_SPI_MACRO_MENU_str:
-	.pascii " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic\r\n10.Set clock idle low\r\n11.Set clock idle high\r\n12.Set edge idle to active\r\n13.Set edge active to idle\r\n14.Sample phase on middle\r\n15.Sample phase on end"
+	.pasciz " 0.Macro menu\r\n 1.Sniff CS low\r\n 2.Sniff all traffic\r\n10.Set clock idle low\r\n11.Set clock idle high\r\n12.Set edge idle to active\r\n13.Set edge active to idle\r\n14.Sample phase on middle\r\n15.Sample phase on end"
 
 	; MSG_SPI_MODE_HEADER_START
 	.section .text.MSG_SPI_MODE_HEADER_START, code
 	.global _MSG_SPI_MODE_HEADER_START_str
 _MSG_SPI_MODE_HEADER_START_str:
-	.pascii "SPI (spd ckp ske smp csl hiz)=( "
+	.pasciz "SPI (spd ckp ske smp csl hiz)=( "
 
 	; MSG_SPI_MODE_IDENTIFIER
 	.section .text.MSG_SPI_MODE_IDENTIFIER, code
 	.global _MSG_SPI_MODE_IDENTIFIER_str
 _MSG_SPI_MODE_IDENTIFIER_str:
-	.pascii "SPI1"
+	.pasciz "SPI1"
 
 	; MSG_SPI_PINS_STATE
 	.section .text.MSG_SPI_PINS_STATE, code
 	.global _MSG_SPI_PINS_STATE_str
 _MSG_SPI_PINS_STATE_str:
-	.pascii "CS\tMISO\tCLK\tMOSI"
+	.pasciz "CS\tMISO\tCLK\tMOSI"
 
 	; MSG_SPI_POLARITY_PROMPT
 	.section .text.MSG_SPI_POLARITY_PROMPT, code
 	.global _MSG_SPI_POLARITY_PROMPT_str
 _MSG_SPI_POLARITY_PROMPT_str:
-	.pascii "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
+	.pasciz "Clock polarity:\r\n 1. Idle low *default\r\n 2. Idle high"
 
 	; MSG_SPI_SAMPLE_PROMPT
 	.section .text.MSG_SPI_SAMPLE_PROMPT, code
 	.global _MSG_SPI_SAMPLE_PROMPT_str
 _MSG_SPI_SAMPLE_PROMPT_str:
-	.pascii "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
+	.pasciz "Input sample phase:\r\n 1. Middle *default\r\n 2. End"
 
 	; MSG_SPI_SPEED_PROMPT
 	.section .text.MSG_SPI_SPEED_PROMPT, code
 	.global _MSG_SPI_SPEED_PROMPT_str
 _MSG_SPI_SPEED_PROMPT_str:
-	.pascii "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
+	.pasciz "Set speed:\r\n 1.  30KHz\r\n 2. 125KHz\r\n 3. 250KHz\r\n 4.   1MHz\r\n 5.  50KHz\r\n 6. 1.3MHz\r\n 7.   2MHz\r\n 8. 2.6MHz\r\n 9. 3.2MHz\r\n10.   4MHz\r\n11. 5.3MHz\r\n12.   8MHz"
 
 	; MSG_UART_MODE_IDENTIFIER
 	.section .text.MSG_UART_MODE_IDENTIFIER, code
 	.global _MSG_UART_MODE_IDENTIFIER_str
 _MSG_UART_MODE_IDENTIFIER_str:
-	.pascii "ART1"
+	.pasciz "ART1"
 
 	; MSG_UART_NORMAL_TO_EXIT
 	.section .text.MSG_UART_NORMAL_TO_EXIT, code
 	.global _MSG_UART_NORMAL_TO_EXIT_str
 _MSG_UART_NORMAL_TO_EXIT_str:
-	.pascii "Normal to exit"
+	.pasciz "Normal to exit"
 
 	; MSG_UART_PINS_STATE
 	.section .text.MSG_UART_PINS_STATE, code
 	.global _MSG_UART_PINS_STATE_str
 _MSG_UART_PINS_STATE_str:
-	.pascii "-\tRxD\t-\tTxD"
+	.pasciz "-\tRxD\t-\tTxD"
 
 	; MSG_UNKNOWN_MACRO_ERROR
 	.section .text.MSG_UNKNOWN_MACRO_ERROR, code
 	.global _MSG_UNKNOWN_MACRO_ERROR_str
 _MSG_UNKNOWN_MACRO_ERROR_str:
-	.pascii "Unknown macro, try ? or (0) for help"
+	.pasciz "Unknown macro, try ? or (0) for help"
 
 	; MSG_USING_ONBOARD_I2C_EEPROM
 	.section .text.MSG_USING_ONBOARD_I2C_EEPROM, code
 	.global _MSG_USING_ONBOARD_I2C_EEPROM_str
 _MSG_USING_ONBOARD_I2C_EEPROM_str:
-	.pascii "Now using on-board EEPROM I2C interface"
+	.pasciz "Now using on-board EEPROM I2C interface"
 
 	; MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT
 	.section .text.MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT, code
 	.global _MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str
 _MSG_VOLTAGE_VPULLUP_ALREADY_PRESENT_str:
-	.pascii "Warning: already a voltage on Vpullup pin"
+	.pasciz "Warning: already a voltage on Vpullup pin"
 
 	; MSG_VPU_3V3_MARKER
 	.section .text.MSG_VPU_3V3_MARKER, code
 	.global _MSG_VPU_3V3_MARKER_str
 _MSG_VPU_3V3_MARKER_str:
-	.pascii "Vpu=3V3, "
+	.pasciz "Vpu=3V3, "
 
 	; MSG_VPU_5V_MARKER
 	.section .text.MSG_VPU_5V_MARKER, code
 	.global _MSG_VPU_5V_MARKER_str
 _MSG_VPU_5V_MARKER_str:
-	.pascii "Vpu=5V, "
+	.pasciz "Vpu=5V, "
 
 	; MSG_VREG_TOO_LOW
 	.section .text.MSG_VREG_TOO_LOW, code
 	.global _MSG_VREG_TOO_LOW_str
 _MSG_VREG_TOO_LOW_str:
-	.pascii "VREG too low, is there a short?"
+	.pasciz "VREG too low, is there a short?"
 
 	; MSG_XSV1_MODE_IDENTIFIER
 	.section .text.MSG_XSV1_MODE_IDENTIFIER, code
 	.global _MSG_XSV1_MODE_IDENTIFIER_str
 _MSG_XSV1_MODE_IDENTIFIER_str:
-	.pascii "XSV1"
+	.pasciz "XSV1"
 

--- a/tools/packstrings/packstrings.py
+++ b/tools/packstrings/packstrings.py
@@ -63,7 +63,7 @@ with open(args.outbase + '.s', 'w') as assembly_output:
         assembly_output.write('_%s_str:\n' % row[0])
         data = row[2].replace('\\', '\\\\').replace('\n', '\\n').replace(
             '\r', '\\r').replace('"', '\\"').replace('\t', '\\t')
-        assembly_output.write('\t.pascii "%s"\n\n' % data)
+        assembly_output.write('\t.pasciz "%s"\n\n' % data)
 
 offset = 0
 BUFFER_WRITE_CALL = 'bp_message_write_buffer'
@@ -76,8 +76,8 @@ with open(args.outbase + '.h', 'w') as header_output:
     for row in sorted(lines):
         call = BUFFER_WRITE_CALL if row[1] == '0' else LINE_WRITE_CALL
         header_output.write('void %s_str(void);\n' % row[0])
-        header_output.write('#define %s %s(__builtin_tbladdress(%s_str), %d)\n' %
-                            (row[0], call, row[0], len(row[2])))
+        header_output.write('#define %s %s(__builtin_tbladdress(%s_str))\n' %
+                            (row[0], call, row[0]))
         offset += len(row[2])
 
     header_output.write('\n#endif /* BP_MESSAGES_%s_H */\n' %


### PR DESCRIPTION
Use null-terminated strings instead of passing the length as a
parameter.

This saves about 670 bytes of code space on v3, and 990 bytes on v4.