### PR TITLE
Fix printing zero on console

### DIFF
--- a/Firmware/base.c
+++ b/Firmware/base.c
@@ -442,6 +442,11 @@ void print_decimal(const uint32_t value, const uint32_t denominator,
   number = value;
   divisor = denominator;
 
+  if (!value){
+      user_serial_transmit_character('0');
+      return;
+  }
+
   for (digit = 0; digit < digits; digit++) {
     current = number / divisor;
     if (first || (current > 0)) {


### PR DESCRIPTION
Not sure if this is the best way to fix it but this worked for me.
If zero is passed to the bp_write_dec_* functions to be printed then nothing will end up on screen.
This can be see if you try to run the self test and no errors are reported.
ex. "Found  errors."
A simple fix was to just check for zero and handle it explicitly.