### PR TITLE
Ignore cmake output files in pirate-loader v4

### DIFF
--- a/Bootloaders/BPv4-bootloader/pirate-loader/.gitignore
+++ b/Bootloaders/BPv4-bootloader/pirate-loader/.gitignore
@@ -1,0 +1,8 @@
+# CMake output
+/CMakeCache.txt
+/CMakeFiles/
+/Makefile
+/cmake_install.cmake
+
+# build output
+/pirate-loader


### PR DESCRIPTION
This just adds a gitignore file to suppress build output in the BPv4 version of pirate-loader.