### PR TITLE
Correct case in gitignore for firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@
 /Firmware/busPirate.X/build/default/
 /Firmware/busPirate.X/debug/
 /Firmware/busPirate.X/dist/
-/Firmware/busPirate.X/nbproject/Makefile-BusPirate_V3.mk
-/Firmware/busPirate.X/nbproject/Makefile-BusPirate_V4.mk
+/Firmware/busPirate.X/nbproject/Makefile-BusPirate_v3.mk
+/Firmware/busPirate.X/nbproject/Makefile-BusPirate_v4.mk
 /Firmware/busPirate.X/nbproject/Makefile-default.mk
 /Firmware/busPirate.X/nbproject/Makefile-genesis.properties
 /Firmware/busPirate.X/nbproject/Makefile-impl.mk


### PR DESCRIPTION
This corrects a case error in the gitignore for some of the MPlab output files that wouldn't have mattered on Windows but is significant on Linux.