### PR TITLE
fix broken seedstudio link for bus pirate v4

### DIFF
--- a/Documentation/bitbang.md
+++ b/Documentation/bitbang.md
@@ -1,7 +1,7 @@
 Bitbang
 =======
 
-![Bitbang session](images/RawSpi.png)
+![Bitbang session](https://raw.githubusercontent.com/BusPirate/Bus_Pirate/master/Documentation/images/Rawspi.png)
 
 There's two new binary I/O libraries in the v2.3 Bus Pirate firmware. Raw bitbang mode provides direct control over the Bus Pirate pins and hardware using a simple single-byte protocol.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Bus Pirate is used through a simple terminal interface, but these applicatio
 # Purchasing
 
 * Bus Pirate v4.0 - *Newer, more space for bigger firmwares*
-  * Worldwide: <http://www.seeedstudio.com/depot/bus-pirate-v4-for-developers-p-740.html>
+  * Worldwide: <https://www.seeedstudio.com/Bus-Pirate-v4-p-740.html>
 
 * Bus Pirate v3.6 - *Proven, more well tested*
   * Worldwide: <http://www.seeedstudio.com/depot/bus-pirate-v3-assembled-p-609.html?cPath=61_68>


### PR DESCRIPTION
The link to the bus pirate v4 on the seedstudio website is outdated.  this PR updates the link.