### PR TITLE
Add external links section to uart doc

### DIFF
--- a/Documentation/bitbang.md
+++ b/Documentation/bitbang.md
@@ -1,7 +1,7 @@
 Bitbang
 =======
 
-![Bitbang session](https://raw.githubusercontent.com/BusPirate/Bus_Pirate/master/Documentation/images/Rawspi.png)
+![Bitbang session](images/RawSpi.png)
 
 There's two new binary I/O libraries in the v2.3 Bus Pirate firmware. Raw bitbang mode provides direct control over the Bus Pirate pins and hardware using a simple single-byte protocol.
 

--- a/Documentation/bitbang.md
+++ b/Documentation/bitbang.md
@@ -1,7 +1,7 @@
 Bitbang
 =======
 
-![Bitbang session](images/RawSpi.png)
+![Bitbang session](https://raw.githubusercontent.com/BusPirate/Bus_Pirate/master/Documentation/images/Rawspi.png)
 
 There's two new binary I/O libraries in the v2.3 Bus Pirate firmware. Raw bitbang mode provides direct control over the Bus Pirate pins and hardware using a simple single-byte protocol.
 

--- a/Documentation/uart.md
+++ b/Documentation/uart.md
@@ -191,3 +191,8 @@ Connect the Bus Pirate transmit pin (TX/MOSI) to the UART device receive pin (RX
 For macros and modes with flow control: CTS is on the CS pin (PIC input from external circuit is passed to FTDI USB->serial chip). RTS is on the CLOCK pin (PIC output mirrors output from FTDI chip). 
 
 Diagram by Uwe Bannow, released under the [GNU free documentation license](http://en.wikipedia.org/wiki/Wikipedia:Text_of_the_GNU_Free_Documentation_License).
+
+External Links
+------------------
+
+- [asciinema.org > connecting to a Raspberry Pi UART via GPIO using a Bus Pirate](https://asciinema.org/a/212988)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Bus Pirate is used through a simple terminal interface, but these applicatio
 # Purchasing
 
 * Bus Pirate v4.0 - *Newer, more space for bigger firmwares*
-  * Worldwide: <http://www.seeedstudio.com/depot/bus-pirate-v4-for-developers-p-740.html>
+  * Worldwide: <https://www.seeedstudio.com/Bus-Pirate-v4-p-740.html>
 
 * Bus Pirate v3.6 - *Proven, more well tested*
   * Worldwide: <http://www.seeedstudio.com/depot/bus-pirate-v3-assembled-p-609.html?cPath=61_68>


### PR DESCRIPTION
Added an external links heading to uart doc, and provided a link, ie. asciicast demoing how to use a bus pirate to connect to a Raspberry Pi provided by the GPIO uart on a Raspberry Pi.