### PR TITLE
github action to make releases on git tags

### DIFF
--- a/.github/workflows/release-bootloader.yml
+++ b/.github/workflows/release-bootloader.yml
@@ -1,0 +1,44 @@
+name: Make a bootloader release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'b*' # Push events to matching b*, i.e. b1.0, b20.15.10
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: { image: fstlx/xc16 }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build BPv4-bootloader v1
+      run: |
+        cd Bootloaders/BPv4-bootloader/firmware-v1/bpv4-bootloader.X
+        prjMakefilesGenerator.sh .
+        make
+        tr [a-z] [A-Z] \
+          < dist/default/production/bpv4-bootloader.X.production.hex \
+          > $GITHUB_WORKSPACE/BPv4-bootloader.${GITHUB_REF#refs/tags/}.hex
+
+    - name: Build BPv3-bootloader v4.5
+      run: |
+        cd Bootloaders/BPv3-bootloader/firmware-v4.5/ds30loader.X
+        prjMakefilesGenerator.sh .
+        make
+        tr [a-z] [A-Z] \
+          < dist/default/production/ds30loader.X.production.hex \
+          > $GITHUB_WORKSPACE/BPv3-bootloader.${GITHUB_REF#refs/tags/}.hex
+
+
+    - name: Create a github release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        prerelease: true
+        files: BP*.hex
+        fail_on_unmatched_files: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Make a release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: { image: fstlx/xc16 }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        cd Firmware/busPirate.X
+        prjMakefilesGenerator.sh .
+        make CONF=BusPirate_v3
+        make CONF=BusPirate_v4
+        mv dist/BusPirate_v3/production/busPirate.X.production.hex $GITHUB_WORKSPACE/BusPirate_v3.${GITHUB_REF#refs/tags/}.hex
+        mv dist/BusPirate_v4/production/busPirate.X.production.hex $GITHUB_WORKSPACE/BusPirate_v4.${GITHUB_REF#refs/tags/}.hex
+
+
+    - name: Create a github release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        prerelease: true
+        files: BusPirate_*.hex
+        fail_on_unmatched_files: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,15 @@ jobs:
         prjMakefilesGenerator.sh .
         make CONF=BusPirate_v3
         make CONF=BusPirate_v4
-        mv dist/BusPirate_v3/production/busPirate.X.production.hex $GITHUB_WORKSPACE/BusPirate_v3.${GITHUB_REF#refs/tags/}.hex
-        mv dist/BusPirate_v4/production/busPirate.X.production.hex $GITHUB_WORKSPACE/BusPirate_v4.${GITHUB_REF#refs/tags/}.hex
+
+    - name: Prepare for release
+      run: |
+        tr [a-z] [A-Z] \
+          < Firmware/busPirate.X/dist/BusPirate_v3/production/busPirate.X.production.hex \
+          > $GITHUB_WORKSPACE/BusPirate_v3.${GITHUB_REF#refs/tags/}.hex
+        tr [a-z] [A-Z] \
+          < Firmware/busPirate.X/dist/BusPirate_v4/production/busPirate.X.production.hex \
+          > $GITHUB_WORKSPACE/BusPirate_v4.${GITHUB_REF#refs/tags/}.hex
 
 
     - name: Create a github release


### PR DESCRIPTION
This github action triggers on tags beginning with `v` (for ex: v1.0),
and builds the firmware using the fstlx/xc16 docker image that contains XC16 and MPLAB X.

Then publishes the built .hex files on github releases, under the same
tag

https://hub.docker.com/r/fstlx/xc16