### PR TITLE
Binary SPI write-then-read doesn't confirm when there's nothing to read

### DIFF
--- a/Firmware/spi.c
+++ b/Firmware/spi.c
@@ -1036,6 +1036,8 @@ void spi_read_write_io(const bool engage_cs) {
 
   if (bytes_to_read > 0) {
     spi_read_to_uart(bytes_to_read);
+  } else {
+    REPORT_IO_SUCCESS();
   }
 
   /* Reset the CS line if needed. */


### PR DESCRIPTION
In binary SPI mode, the [write-then-read command](http://dangerousprototypes.com/docs/SPI_(binary)#00000100_-_Write_then_read) is supposed to send a confirmation byte (`0x01`) when the operation is complete. This happens in [`spi_read_to_uart`](https://github.com/BusPirate/Bus_Pirate/blob/master/Firmware/spi.c#L985-L986), which is called [only when `read > 0`](https://github.com/BusPirate/Bus_Pirate/blob/master/Firmware/spi.c#L1037-L1039).

When there is 0 bytes to read, BusPirate doesn't send any confirmation (and application needs to guess how long it needs to sleep to use SPI again without interfering).

Flashrom uses write-then-read without read to send commands (e.g. erase, program page). It waits for confirmation byte, which never arrives, so flashrom hangs.

This patch fixes the problem. I tested that the confirmation byte is sent and that flashrom no longer hangs.