### PR TITLE
Corrects message displayed for aux pin setting on the v4 board

### DIFF
--- a/Firmware/proc_menu.c
+++ b/Firmware/proc_menu.c
@@ -1573,10 +1573,10 @@ void print_status_info(void) {
 #ifdef BUSPIRATEV4
   switch (mode_configuration.alternate_aux) {
   case 0:
-    BPMSG1087;
+    BPMSG1086;
     break;
   case 1:
-    BPMSG1086;
+    BPMSG1087;
     break;
   case 2:
     BPMSG1263;


### PR DESCRIPTION
Status on the v4 was incorrectly showing a/A/@ controlling the wrong pin (AUX and CS pins were swapped)