### PR TITLE
Fix compile errors with XC16 v2.00

### DIFF
--- a/Firmware/openocd.c
+++ b/Firmware/openocd.c
@@ -212,7 +212,9 @@ void binOpenOCD(void) {
 
       j = (inByte << 8) | inByte2; // number of bit sequences
 
-      j = min(j, BP_JTAG_OPENOCD_BIT_SEQUENCES_LIMIT);
+      if (BP_JTAG_OPENOCD_BIT_SEQUENCES_LIMIT < j) {
+          j = BP_JTAG_OPENOCD_BIT_SEQUENCES_LIMIT;
+      }
       buf[0] = CMD_TAP_SHIFT;
       buf[1] = inByte;
       buf[2] = inByte2;
@@ -253,7 +255,7 @@ void binOpenOCD(void) {
 
         /* Clock TDI and TMS out, while reading TDO in. */
 
-        size_t bits_to_process = min(16, bit_sequences);
+        size_t bits_to_process = 16 < bit_sequences ? 16 : bit_sequences;
         size_t counter;
         uint16_t tdo_data_in = 0;
 

--- a/Firmware/proc_menu.c
+++ b/Firmware/proc_menu.c
@@ -1844,7 +1844,7 @@ void remove_current_character_from_command_line(void) {
     cmdbuf[index] = cmdbuf[index + 1];
 
     /* Write the moved character. */
-    user_serial_transmit_character(cmdbuf[index] != NULL ? cmdbuf[index] : ' ');
+    user_serial_transmit_character(cmdbuf[index] ?: ' ');
 
     /* Update pointer. */
     characters_to_move++;


### PR DESCRIPTION
Fixes #163 

I ran into the same issue compiling the firmware for the first time. These seem like pretty straightforward fixes to me, but I could be wrong. I have very little experience with the Bus Pirate, and was unable to even confirm that I'm hitting these code paths, but the firmware compiles now and I believe these are equivalent statements.

### Compiler error:
> ../openocd.c:215:7: error: implicit declaration of function 'min'

Remove calls to `min()` since I can't find it in the headers. I suspect there _is_ a `min` function we could use for readability, but I don't see it declared anywhere in XC16's `microchip/xc16/v2.00/include` directory, and there were only two instances in a single file, so this seemed okay.

### Compiler error:
> ../proc_menu.c: In function 'remove_current_character_from_command_line':
> ../proc_menu.c:1847:50: error: comparison between pointer and integer

Instead of comparing an integer (aka char) against NULL, simply use the short form of the ternary operator. Documented here: https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html
